### PR TITLE
bug: ByteBuf memory leak in packet handling when releasing before bei…

### DIFF
--- a/proxy/src/main/java/me/internalizable/numdrassl/pipeline/ClientPacketHandler.java
+++ b/proxy/src/main/java/me/internalizable/numdrassl/pipeline/ClientPacketHandler.java
@@ -65,7 +65,8 @@ public final class ClientPacketHandler extends SimpleChannelInboundHandler<Objec
         if (session.getState() == SessionState.CONNECTED) {
             session.sendToBackend(raw.retain());
         } else {
-            raw.release();
+            LOGGER.debug("Session {}: Dropping raw packet - not connected (state={})",
+                session.getSessionId(), session.getState());
         }
     }
 

--- a/proxy/src/main/java/me/internalizable/numdrassl/session/channel/PacketSender.java
+++ b/proxy/src/main/java/me/internalizable/numdrassl/session/channel/PacketSender.java
@@ -97,11 +97,9 @@ public final class PacketSender {
         if (stream.eventLoop().inEventLoop()) {
             doWrite(stream, message, target);
         } else {
-            // Retain ByteBuf when crossing event loops to prevent premature release
-            // The encoder will release it after writing
-            if (message instanceof ByteBuf buf) {
-                buf.retain();
-            }
+
+            //bytebuf released by SimpleChannelInbound so no need to track
+
             stream.eventLoop().execute(() -> {
                 if (stream.isActive()) {
                     doWrite(stream, message, target);


### PR DESCRIPTION
…ng garbage collected by SimpleChannelInbound

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Bug Fix: ByteBuf Memory Leak in Packet Handling

**Category** | Resource Management / Memory Leak Fix  
**Impact** | ClientPacketHandler, PacketSender (packet routing layer)  
**Summary** | Fixed a ByteBuf memory leak caused by improper reference counting in cross-thread packet dispatching. The issue occurred when ByteBufs were retained for event loop task scheduling but never released, and when they were manually released in non-connected session states despite being automatically released by SimpleChannelInboundHandler. Changes:
- **ClientPacketHandler.handleRawPacket()**: Removed implicit release path for non-connected sessions; now only logs and relies on automatic cleanup by SimpleChannelInboundHandler
- **PacketSender.sendToStream()**: Removed ByteBuf retention when dispatching across event loops; added comment clarifying that SimpleChannelInbound handles automatic release, eliminating the need for manual reference count management in cross-thread scenarios

**Breaking Changes** | None  
**Compatibility** | Fully compatible; internal resource management refactor with no API or protocol changes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->