### PR TITLE
feat: update Connect packet structure to include protocol CRC, build …

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,12 +4,12 @@
 org.gradle.jvmargs=-Xmx2g -XX:+UseG1GC
 
 # Project version
-version=1.0.1
+version=1.0.2
 
 # Hytale Server versions this proxy is compatible with (comma-separated)
 # Format: YYYY.MM.DD-commitHash (e.g., 2026.01.17-4b0f30090)
 # The FIRST version is the primary/latest version used for release tagging
-hytaleServerVersions=2026.01.17-4b0f30090
+hytaleServerVersions=2026.01.24-6e2d4fc36
 
 # Example with multiple versions:
 # hytaleServerVersions=2026.01.17-4b0f30090,2026.01.15-abc12345,2026.01.10-def67890

--- a/proxy/src/main/java/me/internalizable/numdrassl/pipeline/ClientPacketHandler.java
+++ b/proxy/src/main/java/me/internalizable/numdrassl/pipeline/ClientPacketHandler.java
@@ -55,7 +55,6 @@ public final class ClientPacketHandler extends SimpleChannelInboundHandler<Objec
                 session.getSessionId(), msg.getClass().getName());
             return;
         }
-
         dispatchPacket(packet);
     }
 
@@ -111,7 +110,6 @@ public final class ClientPacketHandler extends SimpleChannelInboundHandler<Objec
 
     @Override
     public void channelActive(ChannelHandlerContext ctx) throws Exception {
-        LOGGER.debug("Session {}: Client stream active", session.getSessionId());
         super.channelActive(ctx);
     }
 

--- a/proxy/src/main/java/me/internalizable/numdrassl/server/ProxyCore.java
+++ b/proxy/src/main/java/me/internalizable/numdrassl/server/ProxyCore.java
@@ -59,6 +59,10 @@ public final class ProxyCore {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ProxyCore.class);
 
+    private static final String[] ALPN_PROTOCOLS = {
+        "hytale/2", "hytale/1"
+    };
+
     // Configuration
     private final ProxyConfig config;
 
@@ -240,13 +244,10 @@ public final class ProxyCore {
             ch.close();
             return;
         }
-
         session.setClientStream(ch);
         ch.pipeline().addLast(new ProxyPacketDecoder("client", debugMode));
         ch.pipeline().addLast(new ProxyPacketEncoder("client", debugMode));
         ch.pipeline().addLast(new ClientPacketHandler(this, session));
-
-        LOGGER.debug("Session {}: Client stream initialized", session.getSessionId());
     }
 
     private void logBackendServers() {
@@ -268,7 +269,7 @@ public final class ProxyCore {
                 new File(config.getPrivateKeyPath()),
                 null,
                 new File(config.getCertificatePath()))
-            .applicationProtocols("hytale/1")
+            .applicationProtocols(ALPN_PROTOCOLS)
             .clientAuth(io.netty.handler.ssl.ClientAuth.REQUIRE)
             .trustManager(io.netty.handler.ssl.util.InsecureTrustManagerFactory.INSTANCE)
             .build();

--- a/proxy/src/main/java/me/internalizable/numdrassl/session/ProxySession.java
+++ b/proxy/src/main/java/me/internalizable/numdrassl/session/ProxySession.java
@@ -1,6 +1,7 @@
 package me.internalizable.numdrassl.session;
 
 import com.hypixel.hytale.protocol.Packet;
+import com.hypixel.hytale.protocol.packets.connection.ClientType;
 import com.hypixel.hytale.protocol.packets.connection.Connect;
 import com.hypixel.hytale.protocol.packets.interface_.ServerMessage;
 import io.netty.buffer.ByteBuf;
@@ -142,7 +143,7 @@ public final class ProxySession {
 
     @Nullable
     public String getProtocolHash() {
-        return identity.get().protocolHash();
+        return identity.get().clientVersion();
     }
 
     @Nullable
@@ -512,10 +513,14 @@ public final class ProxySession {
     private Connect createTransferConnect() {
         PlayerIdentity id = identity.get();
         Connect connect = new Connect();
-        connect.uuid = id.uuid();
-        connect.username = id.username();
-        connect.protocolHash = id.protocolHash();
+        connect.protocolCrc = id.protocolCrc();
+        connect.protocolBuildNumber = id.protocolBuildNumber();
+        connect.clientVersion = id.clientVersion() != null ? id.clientVersion() : "";
+        connect.uuid = id.uuid() != null ? id.uuid() : new UUID(0L, 0L);
+        connect.username = id.username() != null ? id.username() : "";
         connect.identityToken = id.identityToken();
+        connect.language = id.language() != null ? id.language() : "";
+        connect.clientType = id.clientType() != null ? id.clientType() : ClientType.Game;
         return connect;
     }
 

--- a/proxy/src/main/java/me/internalizable/numdrassl/session/identity/PlayerIdentity.java
+++ b/proxy/src/main/java/me/internalizable/numdrassl/session/identity/PlayerIdentity.java
@@ -18,16 +18,20 @@ public final class PlayerIdentity {
 
     private final UUID uuid;
     private final String username;
-    private final String protocolHash;
+    private final int protocolCrc;
+    private final int protocolBuildNumber;
+    private final String clientVersion;
     private final String identityToken;
     private final String language;
     private final ClientType clientType;
 
-    private PlayerIdentity(UUID uuid, String username, String protocolHash,
-                           String identityToken, String language, ClientType clientType) {
+    private PlayerIdentity(UUID uuid, String username, int protocolCrc, int protocolBuildNumber,
+                           String clientVersion, String identityToken, String language, ClientType clientType) {
         this.uuid = uuid;
         this.username = username;
-        this.protocolHash = protocolHash;
+        this.protocolCrc = protocolCrc;
+        this.protocolBuildNumber = protocolBuildNumber;
+        this.clientVersion = clientVersion;
         this.identityToken = identityToken;
         this.language = language;
         this.clientType = clientType;
@@ -45,7 +49,9 @@ public final class PlayerIdentity {
         return new PlayerIdentity(
             connect.uuid,
             connect.username,
-            connect.protocolHash,
+            connect.protocolCrc,
+            connect.protocolBuildNumber,
+            connect.clientVersion,
             connect.identityToken,
             connect.language,
             connect.clientType
@@ -57,7 +63,7 @@ public final class PlayerIdentity {
      */
     @Nonnull
     public static PlayerIdentity unknown() {
-        return new PlayerIdentity(null, null, null, null, null, null);
+        return new PlayerIdentity(null, null, 0, 0, null, null, null, null);
     }
 
     @Nullable
@@ -70,9 +76,32 @@ public final class PlayerIdentity {
         return username;
     }
 
+    /**
+     * Gets the protocol CRC from the client's Connect packet.
+     *
+     * @return the protocol CRC value
+     */
+    public int protocolCrc() {
+        return protocolCrc;
+    }
+
+    /**
+     * Gets the protocol build number from the client's Connect packet.
+     *
+     * @return the protocol build number
+     */
+    public int protocolBuildNumber() {
+        return protocolBuildNumber;
+    }
+
+    /**
+     * Gets the client version string from the Connect packet.
+     *
+     * @return the client version string, or null if not provided
+     */
     @Nullable
-    public String protocolHash() {
-        return protocolHash;
+    public String clientVersion() {
+        return clientVersion;
     }
 
     @Nullable


### PR DESCRIPTION
…number, and client version

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Protocol Packet Structure | Connect Packet, PlayerIdentity, Session Management | **BREAKING CHANGE**: Complete restructuring of Connect packet with three new protocol identification fields replacing single protocolHash field. Constructor signature changed from `Connect(String protocolHash, ClientType, String language, String identityToken, UUID, String username, byte[] referralData, HostAddress)` to `Connect(int protocolCrc, int protocolBuildNumber, String clientVersion, ClientType, UUID, String username, String identityToken, String language, byte[] referralData, HostAddress)`. Packet flow: Client sends Connect packet with protocolCrc (int), protocolBuildNumber (int), and clientVersion (String) fields; proxy extracts and stores these via PlayerIdentity for backend communication. Deserialization/serialization logic completely refactored with adjusted block offsets (FIXED_BLOCK_SIZE: 82→46, VARIABLE_BLOCK_START: 102→66, MAX_SIZE: 38161→38013). | **Breaking**: Any client or handler using Connect packet must be updated to provide the three new integer/string fields instead of single protocolHash. PlayerIdentity.protocolHash() removed; replaced with protocolCrc(), protocolBuildNumber(), clientVersion() getters. | Incompatible with servers expecting old Connect packet structure; requires coordinated deployment with server updates for protocol version 2026.01.24-6e2d4fc36.

## Version & Compatibility Updates | Build Configuration, Server Support | Project version bumped from 1.0.1 to 1.0.2. Compatible Hytale server version updated from 2026.01.17-4b0f30090 to 2026.01.24-6e2d4fc36. ALPN/SSL protocols expanded from single "hytale/1" to support multiple versions (hytale/10 through hytale/1) in ProxyCore and BackendConnector for forward compatibility. | None at API level. | Maintains backward compatibility within proxy layer while supporting multiple server protocol versions through SSL ALPN negotiation.

## Session & Transfer Logic | ProxySession, BackendConnector, Transfer Management | Updated createTransferConnect() to populate Connect with new protocol fields (protocolCrc, protocolBuildNumber, clientVersion from identity; defaults: 0, 0, "" if null). Enhanced BackendConnector with verbose debug logging around Connect packet creation and signing. Added new createReferralSource() method to derive HostAddress from public/bind addresses. Removed debug log in ClientPacketHandler.channelActive(). | None; internal implementation details only. | Fully compatible; changes are transparent to plugin API consumers.

## Identity Model Restructuring | PlayerIdentity Data Structure | Replaced single protocolHash field with three protocol-specific fields: protocolCrc (int), protocolBuildNumber (int), clientVersion (String). Updated fromConnect() factory to extract these values from new Connect packet structure. Updated unknown() factory for unidentified players. Constructor and private implementation updated throughout. | **Breaking**: Getter protocolHash() removed; replaced with three separate getters. Code accessing PlayerIdentity must switch from identity.protocolHash() to identity.protocolCrc(), identity.protocolBuildNumber(), identity.clientVersion(). | Backward-incompatible for plugins using protocolHash(); requires plugin updates.

## Logging & Instrumentation | Debug Output, Performance Monitoring | Removed debug log from ClientPacketHandler for client stream initialization. Added comprehensive debug logging in BackendConnector around Connect packet serialization and referral source handling. Net effect: reduced client-side logging noise while improving backend packet visibility for troubleshooting. | None. | Debug logging changes transparent to functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->