### PR TITLE
Support version 2026.01.24-6e2d4fc36 of Hytale

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,12 +4,12 @@
 org.gradle.jvmargs=-Xmx2g -XX:+UseG1GC
 
 # Project version
-version=1.0.1
+version=1.0.2
 
 # Hytale Server versions this proxy is compatible with (comma-separated)
 # Format: YYYY.MM.DD-commitHash (e.g., 2026.01.17-4b0f30090)
 # The FIRST version is the primary/latest version used for release tagging
-hytaleServerVersions=2026.01.17-4b0f30090
+hytaleServerVersions=2026.01.24-6e2d4fc36
 
 # Example with multiple versions:
 # hytaleServerVersions=2026.01.17-4b0f30090,2026.01.15-abc12345,2026.01.10-def67890

--- a/proxy/src/main/java/me/internalizable/numdrassl/pipeline/ClientPacketHandler.java
+++ b/proxy/src/main/java/me/internalizable/numdrassl/pipeline/ClientPacketHandler.java
@@ -55,7 +55,6 @@ public final class ClientPacketHandler extends SimpleChannelInboundHandler<Objec
                 session.getSessionId(), msg.getClass().getName());
             return;
         }
-
         dispatchPacket(packet);
     }
 
@@ -111,7 +110,6 @@ public final class ClientPacketHandler extends SimpleChannelInboundHandler<Objec
 
     @Override
     public void channelActive(ChannelHandlerContext ctx) throws Exception {
-        LOGGER.debug("Session {}: Client stream active", session.getSessionId());
         super.channelActive(ctx);
     }
 

--- a/proxy/src/main/java/me/internalizable/numdrassl/server/ProxyCore.java
+++ b/proxy/src/main/java/me/internalizable/numdrassl/server/ProxyCore.java
@@ -59,6 +59,10 @@ public final class ProxyCore {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ProxyCore.class);
 
+    private static final String[] ALPN_PROTOCOLS = {
+        "hytale/2", "hytale/1"
+    };
+
     // Configuration
     private final ProxyConfig config;
 
@@ -240,13 +244,10 @@ public final class ProxyCore {
             ch.close();
             return;
         }
-
         session.setClientStream(ch);
         ch.pipeline().addLast(new ProxyPacketDecoder("client", debugMode));
         ch.pipeline().addLast(new ProxyPacketEncoder("client", debugMode));
         ch.pipeline().addLast(new ClientPacketHandler(this, session));
-
-        LOGGER.debug("Session {}: Client stream initialized", session.getSessionId());
     }
 
     private void logBackendServers() {
@@ -268,7 +269,7 @@ public final class ProxyCore {
                 new File(config.getPrivateKeyPath()),
                 null,
                 new File(config.getCertificatePath()))
-            .applicationProtocols("hytale/1")
+            .applicationProtocols(ALPN_PROTOCOLS)
             .clientAuth(io.netty.handler.ssl.ClientAuth.REQUIRE)
             .trustManager(io.netty.handler.ssl.util.InsecureTrustManagerFactory.INSTANCE)
             .build();

--- a/proxy/src/main/java/me/internalizable/numdrassl/session/ProxySession.java
+++ b/proxy/src/main/java/me/internalizable/numdrassl/session/ProxySession.java
@@ -1,6 +1,7 @@
 package me.internalizable.numdrassl.session;
 
 import com.hypixel.hytale.protocol.Packet;
+import com.hypixel.hytale.protocol.packets.connection.ClientType;
 import com.hypixel.hytale.protocol.packets.connection.Connect;
 import com.hypixel.hytale.protocol.packets.interface_.ServerMessage;
 import io.netty.buffer.ByteBuf;
@@ -142,7 +143,7 @@ public final class ProxySession {
 
     @Nullable
     public String getProtocolHash() {
-        return identity.get().protocolHash();
+        return identity.get().clientVersion();
     }
 
     @Nullable
@@ -512,10 +513,14 @@ public final class ProxySession {
     private Connect createTransferConnect() {
         PlayerIdentity id = identity.get();
         Connect connect = new Connect();
-        connect.uuid = id.uuid();
-        connect.username = id.username();
-        connect.protocolHash = id.protocolHash();
+        connect.protocolCrc = id.protocolCrc();
+        connect.protocolBuildNumber = id.protocolBuildNumber();
+        connect.clientVersion = id.clientVersion() != null ? id.clientVersion() : "";
+        connect.uuid = id.uuid() != null ? id.uuid() : new UUID(0L, 0L);
+        connect.username = id.username() != null ? id.username() : "";
         connect.identityToken = id.identityToken();
+        connect.language = id.language() != null ? id.language() : "";
+        connect.clientType = id.clientType() != null ? id.clientType() : ClientType.Game;
         return connect;
     }
 

--- a/proxy/src/main/java/me/internalizable/numdrassl/session/identity/PlayerIdentity.java
+++ b/proxy/src/main/java/me/internalizable/numdrassl/session/identity/PlayerIdentity.java
@@ -18,16 +18,20 @@ public final class PlayerIdentity {
 
     private final UUID uuid;
     private final String username;
-    private final String protocolHash;
+    private final int protocolCrc;
+    private final int protocolBuildNumber;
+    private final String clientVersion;
     private final String identityToken;
     private final String language;
     private final ClientType clientType;
 
-    private PlayerIdentity(UUID uuid, String username, String protocolHash,
-                           String identityToken, String language, ClientType clientType) {
+    private PlayerIdentity(UUID uuid, String username, int protocolCrc, int protocolBuildNumber,
+                           String clientVersion, String identityToken, String language, ClientType clientType) {
         this.uuid = uuid;
         this.username = username;
-        this.protocolHash = protocolHash;
+        this.protocolCrc = protocolCrc;
+        this.protocolBuildNumber = protocolBuildNumber;
+        this.clientVersion = clientVersion;
         this.identityToken = identityToken;
         this.language = language;
         this.clientType = clientType;
@@ -45,7 +49,9 @@ public final class PlayerIdentity {
         return new PlayerIdentity(
             connect.uuid,
             connect.username,
-            connect.protocolHash,
+            connect.protocolCrc,
+            connect.protocolBuildNumber,
+            connect.clientVersion,
             connect.identityToken,
             connect.language,
             connect.clientType
@@ -57,7 +63,7 @@ public final class PlayerIdentity {
      */
     @Nonnull
     public static PlayerIdentity unknown() {
-        return new PlayerIdentity(null, null, null, null, null, null);
+        return new PlayerIdentity(null, null, 0, 0, null, null, null, null);
     }
 
     @Nullable
@@ -70,9 +76,32 @@ public final class PlayerIdentity {
         return username;
     }
 
+    /**
+     * Gets the protocol CRC from the client's Connect packet.
+     *
+     * @return the protocol CRC value
+     */
+    public int protocolCrc() {
+        return protocolCrc;
+    }
+
+    /**
+     * Gets the protocol build number from the client's Connect packet.
+     *
+     * @return the protocol build number
+     */
+    public int protocolBuildNumber() {
+        return protocolBuildNumber;
+    }
+
+    /**
+     * Gets the client version string from the Connect packet.
+     *
+     * @return the client version string, or null if not provided
+     */
     @Nullable
-    public String protocolHash() {
-        return protocolHash;
+    public String clientVersion() {
+        return clientVersion;
     }
 
     @Nullable


### PR DESCRIPTION
This adds preliminary support for Hytale 2.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Protocol Packet Structure | Connect Packet, Identity Management, Backend Connection | 

The Connect packet protocol has been restructured to support Hytale 2026.01.24-6e2d4fc36. The new format replaces the single `protocolHash` field with a three-component protocol identifier: `protocolCrc` (int), `protocolBuildNumber` (int), and `clientVersion` (String). The packet header layout was reorganized with FIXED_BLOCK_SIZE reduced from 82 to 46 bytes and VARIABLE_BLOCK_START from 102 to 66 bytes. Serialization/deserialization logic was completely rewritten to accommodate new field ordering and offsets. The `identityToken` field was promoted to the public API and made explicitly non-null, while `language` transitioned from optional to mandatory with default values. These changes apply at the packet boundary between client and proxy, and between proxy and backend servers.

## Session Identity Management | PlayerIdentity, ProxySession | 

The `PlayerIdentity` class now represents the protocol version triplet (protocolCrc, protocolBuildNumber, clientVersion) instead of a single protocolHash field. Getters `protocolCrc()` and `protocolBuildNumber()` were added, while `protocolHash()` was replaced with `clientVersion()`. `ProxySession.getProtocolHash()` now delegates to `clientVersion()`, effectively changing its return semantics. The session transfer flow in `createTransferConnect()` was expanded to populate all protocol and identity fields (protocolCrc, protocolBuildNumber, clientVersion, uuid, username, language, clientType) with null-safe defaults where applicable.

## TLS/ALPN Protocol Negotiation | ProxyCore, BackendConnector | 

Client-facing connections now negotiate ALPN protocols "hytale/2" and "hytale/1" via a new `ALPN_PROTOCOLS` constant in `ProxyCore`. Backend connections expanded to support a broader range of ALPN versions ("hytale/10" through "hytale/1") to handle diverse backend server versions. Backend connection creation now attaches a `referralSource` (HostAddress) to the Connect packet for proper proxy identification to backend servers.

## Breaking Changes | 

- **Connect packet binary format**: Previous protocol hash-based format incompatible with new CRC/BuildNumber/Version format; requires coordinated upgrade
- **PlayerIdentity constructor**: Parameter order and types changed (protocolHash removed, protocolCrc/protocolBuildNumber/clientVersion added); no backward compatibility
- **PlayerIdentity.protocolHash() getter**: Removed and replaced with clientVersion(); code calling getProtocolHash() will fail
- **ProxySession.getProtocolHash()**: Return value semantics changed (now returns clientVersion instead of protocol hash value)
- **Connect packet field visibility**: identityToken promoted from internal to public; language changed to mandatory (non-null)
- **ClientPacketHandler**: Debug logging removed from channelActive; log consumers will not see session initialization diagnostics

## Compatibility | 

Version increment: gradle.properties bumped from 1.0.1 to 1.0.2. Hytale server version updated from 2026.01.17-4b0f30090 to 2026.01.24-6e2d4fc36 as the canonical version. Backward compatibility with older Hytale protocol versions (<2026.01.24) is broken; clients/servers using prior Connect packet format will fail deserialization at the 46-byte fixed header boundary. The expanded ALPN protocol list (hytale/1-2 for clients, hytale/1-10 for backend) should maintain compatibility with older backend servers supporting "hytale/1", though actual version negotiation depends on backend implementation. No database schema or configuration file changes indicated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->