### PR TITLE
feat: add server name environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,7 +385,7 @@ The plugin JAR is at: `bridge/build/libs/bridge-1.0-SNAPSHOT.jar`
 
 ### 2. Install on Backend Server
 
-Copy `bridge-1.0-SNAPSHOT.jar` to your Hytale server's `plugins/` directory.
+Copy `bridge-1.0-SNAPSHOT.jar` to your Hytale server's `mods/` directory.
 
 ### 3. Start Backend in Insecure Mode
 
@@ -834,6 +834,17 @@ Output locations:
 | `sessions` | List all connected sessions |
 | `stop` | Gracefully shut down the proxy |
 | `help` | Show available commands |
+
+---
+
+## Bridge: Supported Environment Variables
+
+The Bridge plugin supports the following environment variables:
+
+| Command | Description |
+|---------|-------------|
+| `NUMDRASSL_SERVERNAME` | Overrides the serverName from the Bridge config. |
+| `NUMDRASSL_SECRET` | Overrides the shared secret from the Bridge config. |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -841,10 +841,10 @@ Output locations:
 
 The Bridge plugin supports the following environment variables:
 
-| Command | Description |
-|---------|-------------|
+| Environment Variable   | Description |
+|------------------------|-------------|
 | `NUMDRASSL_SERVERNAME` | Overrides the serverName from the Bridge config. |
-| `NUMDRASSL_SECRET` | Overrides the shared secret from the Bridge config. |
+| `NUMDRASSL_SECRET`     | Overrides the shared secret from the Bridge config. |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -330,6 +330,15 @@ redisDatabase: 0
 
 Each backend server requires the Bridge plugin with matching `proxySecret`.
 
+### Proxy: Supported Environment Variables
+
+The Proxy supports the following environment variables:
+
+| Environment Variable   | Description                                       |
+|------------------------|---------------------------------------------------|
+| `NUMDRASSL_SECRET`     | Overrides the secret from the proxy config. |
+
+
 ### Cluster Configuration Notes
 
 > ⚠️ **Important Security Warnings:**
@@ -415,6 +424,15 @@ Block direct connections to your backend server from the internet. Only allow co
 iptables -A INPUT -p udp --dport 5520 -s 192.168.1.50 -j ACCEPT
 iptables -A INPUT -p udp --dport 5520 -j DROP
 ```
+
+### Bridge: Supported Environment Variables
+
+The Bridge plugin supports the following environment variables:
+
+| Environment Variable   | Description |
+|------------------------|-------------|
+| `NUMDRASSL_SERVERNAME` | Overrides the serverName from the Bridge config. |
+| `NUMDRASSL_SECRET`     | Overrides the shared secret from the Bridge config. |
 
 ---
 
@@ -834,17 +852,6 @@ Output locations:
 | `sessions` | List all connected sessions |
 | `stop` | Gracefully shut down the proxy |
 | `help` | Show available commands |
-
----
-
-## Bridge: Supported Environment Variables
-
-The Bridge plugin supports the following environment variables:
-
-| Environment Variable   | Description |
-|------------------------|-------------|
-| `NUMDRASSL_SERVERNAME` | Overrides the serverName from the Bridge config. |
-| `NUMDRASSL_SECRET`     | Overrides the shared secret from the Bridge config. |
 
 ---
 

--- a/bridge/src/main/java/me/internalizable/numdrassl/Bridge.java
+++ b/bridge/src/main/java/me/internalizable/numdrassl/Bridge.java
@@ -119,12 +119,12 @@ public class Bridge extends JavaPlugin {
 
     private String getServerName() {
         String envServerName = System.getenv("NUMDRASSL_SERVERNAME");
-        if(envServerName != null && !envServerName.isEmpty()) {
+        if (envServerName != null && !envServerName.isEmpty()) {
             return envServerName;
         }
 
         String configServerName = config.get().getServerName();
-        if(configServerName != null && !configServerName.isEmpty()) {
+        if (configServerName != null && !configServerName.isEmpty()) {
             return configServerName;
         }
 

--- a/bridge/src/main/java/me/internalizable/numdrassl/Bridge.java
+++ b/bridge/src/main/java/me/internalizable/numdrassl/Bridge.java
@@ -128,7 +128,7 @@ public class Bridge extends JavaPlugin {
             return configServerName;
         }
 
-        getLogger().at(Level.WARNING).log("No proxy server name configured! Using default \"main\".");
+        getLogger().at(Level.WARNING).log("No server name configured! Using default \"main\".");
         return "main";
     }
 

--- a/bridge/src/main/java/me/internalizable/numdrassl/Bridge.java
+++ b/bridge/src/main/java/me/internalizable/numdrassl/Bridge.java
@@ -79,7 +79,7 @@ public class Bridge extends JavaPlugin {
                     buf,
                     event.getUuid(),
                     event.getUsername(),
-                    this.config.get().getServerName(),
+                    this.getServerName(),
                     secret
             );
 
@@ -115,6 +115,21 @@ public class Bridge extends JavaPlugin {
 
         getLogger().at(Level.WARNING).log("No proxy secret configured! Using random secret.");
         return RandomUtil.generateSecureRandomString(32).getBytes(StandardCharsets.UTF_8);
+    }
+
+    private String getServerName() {
+        String envServerName = System.getenv("NUMDRASSL_SERVERNAME");
+        if(envServerName != null && !envServerName.isEmpty()) {
+            return envServerName;
+        }
+
+        String configServerName = config.get().getServerName();
+        if(configServerName != null && !configServerName.isEmpty()) {
+            return configServerName;
+        }
+
+        getLogger().at(Level.WARNING).log("No proxy server name configured! Using default \"main\".");
+        return "main";
     }
 
     /**


### PR DESCRIPTION
This PR introduces `getServerName()` to resolve the server name. It prefers the `NUMDRASSL_SERVERNAME` environment variable, falls back to the configured `serverName `from the config, and defaults to "main" with a warning if neither is set.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Feature Enhancement | Bridge Module, Docs (README) | Adds private getServerName() in Bridge to resolve the server name with this precedence: 1) NUMDRASSL_SERVERNAME environment variable; 2) config.get().getServerName(); 3) default "main" and emit a warning if neither is set. verifyPlayerReferral() now uses this.getServerName() when calling SecretMessageUtil.validateAndDecodePlayerInfoReferral. No public API or protocol changes. README updated: Backend plugin install path changed from plugins/ to mods/, Bridge and Proxy supported environment variables documented (NUMDRASSL_SERVERNAME and NUMDRASSL_SECRET), and the environment-variable documentation appears duplicated in multiple sections. | Breaking Changes: None (no public API or protocol changes) | Compatibility: Fully Compatible
<!-- end of auto-generated comment: release notes by coderabbit.ai -->