### PR TITLE
feat: add find command

### DIFF
--- a/proxy/src/main/java/me/internalizable/numdrassl/command/builtin/FindCommand.java
+++ b/proxy/src/main/java/me/internalizable/numdrassl/command/builtin/FindCommand.java
@@ -1,0 +1,64 @@
+package me.internalizable.numdrassl.command.builtin;
+
+import me.internalizable.numdrassl.api.Numdrassl;
+import me.internalizable.numdrassl.api.ProxyServer;
+import me.internalizable.numdrassl.api.chat.ChatMessageBuilder;
+import me.internalizable.numdrassl.api.command.Command;
+import me.internalizable.numdrassl.api.command.CommandResult;
+import me.internalizable.numdrassl.api.command.CommandSource;
+import me.internalizable.numdrassl.api.player.Player;
+import me.internalizable.numdrassl.api.server.RegisteredServer;
+
+import javax.annotation.Nonnull;
+
+public class FindCommand implements Command {
+    @Nonnull
+    @Override
+    public String getName() {
+        return "find";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Shows which server a player is currently on";
+    }
+
+    @Override
+    public String getUsage() {
+        return "/find [player-name]";
+    }
+
+    @Nonnull
+    @Override
+    public CommandResult execute(@Nonnull CommandSource source, @Nonnull String[] args) {
+        ProxyServer proxy = Numdrassl.getProxy();
+
+        // No arguments
+        if (args.length == 0) {
+            source.sendMessage(ChatMessageBuilder.create()
+                    .red("Usage: " + this.getUsage()));
+            return CommandResult.success();
+        }
+
+        String playerName = args[0];
+
+        if (proxy.getPlayer(playerName).isEmpty()) {
+            source.sendMessage(ChatMessageBuilder.create()
+                    .red("That player could not be found."));
+            return CommandResult.success();
+        }
+
+        Player player = proxy.getPlayer(playerName).get();
+        if (player.getCurrentServer().isEmpty()) {
+            source.sendMessage(ChatMessageBuilder.create()
+                    .red("Unable to find the player´s server"));
+            return CommandResult.success();
+        }
+
+        RegisteredServer currentServer = player.getCurrentServer().get();
+        source.sendMessage(ChatMessageBuilder.create()
+                .green(playerName + " is currently on " + currentServer.getName()));
+
+        return CommandResult.success();
+    }
+}

--- a/proxy/src/main/java/me/internalizable/numdrassl/command/builtin/FindCommand.java
+++ b/proxy/src/main/java/me/internalizable/numdrassl/command/builtin/FindCommand.java
@@ -25,7 +25,7 @@ public class FindCommand implements Command {
 
     @Override
     public String getUsage() {
-        return "/find [player-name]";
+        return "/find <player-name>";
     }
 
     @Nonnull
@@ -44,14 +44,16 @@ public class FindCommand implements Command {
 
         if (proxy.getPlayer(playerName).isEmpty()) {
             source.sendMessage(ChatMessageBuilder.create()
-                    .red("That player could not be found."));
+                    .red("[X] ")
+                    .gray("That player could not be found."));
             return CommandResult.success();
         }
 
         Player player = proxy.getPlayer(playerName).get();
         if (player.getCurrentServer().isEmpty()) {
             source.sendMessage(ChatMessageBuilder.create()
-                    .red("Unable to find the player´s server"));
+                    .red("[X] ")
+                    .gray("Unable to find the player's server."));
             return CommandResult.success();
         }
 

--- a/proxy/src/main/java/me/internalizable/numdrassl/plugin/NumdrasslProxy.java
+++ b/proxy/src/main/java/me/internalizable/numdrassl/plugin/NumdrasslProxy.java
@@ -17,12 +17,7 @@ import me.internalizable.numdrassl.cluster.NumdrasslClusterManager;
 import me.internalizable.numdrassl.command.CommandEventListener;
 import me.internalizable.numdrassl.command.ConsoleCommandSource;
 import me.internalizable.numdrassl.command.NumdrasslCommandManager;
-import me.internalizable.numdrassl.command.builtin.AuthCommand;
-import me.internalizable.numdrassl.command.builtin.HelpCommand;
-import me.internalizable.numdrassl.command.builtin.NumdrasslCommand;
-import me.internalizable.numdrassl.command.builtin.ServerCommand;
-import me.internalizable.numdrassl.command.builtin.SessionsCommand;
-import me.internalizable.numdrassl.command.builtin.StopCommand;
+import me.internalizable.numdrassl.command.builtin.*;
 import me.internalizable.numdrassl.event.api.NumdrasslEventManager;
 import me.internalizable.numdrassl.messaging.local.LocalMessagingService;
 import me.internalizable.numdrassl.messaging.redis.RedisMessagingService;
@@ -162,6 +157,7 @@ public final class NumdrasslProxy implements ProxyServer {
         commandManager.register(this, new SessionsCommand(core));
         commandManager.register(this, new StopCommand(core), "shutdown", "end");
         commandManager.register(this, new ServerCommand(), "srv");
+        commandManager.register(this, new FindCommand(), "find-server");
         commandManager.register(this, new NumdrasslCommand(), "nd", "proxy");
     }
 


### PR DESCRIPTION
Added find command to find server player is on.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Feature Addition | Command System (proxy/src/main/java/me/internalizable/numdrassl/command/builtin/FindCommand.java, proxy/src/main/java/me/internalizable/numdrassl/plugin/NumdrasslProxy.java) | Adds a new builtin FindCommand allowing lookup of which server a given player is currently on. Usage: /find <player-name>. Behavior: validates arguments, looks up the player, resolves the player's current RegisteredServer, and sends colorized feedback (red on errors, green on success) via ChatMessageBuilder. All execution paths return CommandResult.success(), making the command non-fatal on errors. The command is registered during proxy initialization and exposed as "find-server" (command class name/primary name remains "find"). The commit also standardizes error message wording/format. | None | Fully Compatible

Code Organization | Plugin Initialization (proxy/src/main/java/me/internalizable/numdrassl/plugin/NumdrasslProxy.java) | Replaced explicit builtin command imports with a wildcard import for the builtin package and registered the new FindCommand in the existing builtin registration flow (registerBuiltinCommands), so the command is available at startup alongside other builtin commands. | None | Fully Compatible

Integration | Command Manager / User UX (proxy command system) | Integrates FindCommand into the command set exposed to users/admins; provides clear usage and error messages for missing arguments, unknown players, or absent server information. Minor messaging consistency improvement from the "fix: standardize error message" commit. | None | Fully Compatible
<!-- end of auto-generated comment: release notes by coderabbit.ai -->