### PR TITLE
feat: Extend /server command to allow transferring other players

### DIFF
--- a/README.md
+++ b/README.md
@@ -844,14 +844,15 @@ Output locations:
 
 ## Console Commands
 
-| Command | Description |
-|---------|-------------|
+| Command      | Description                            |
+|--------------|----------------------------------------|
 | `auth login` | Start OAuth device flow authentication |
-| `auth status` | Show current authentication status |
-| `auth logout` | Clear stored credentials |
-| `sessions` | List all connected sessions |
-| `stop` | Gracefully shut down the proxy |
-| `help` | Show available commands |
+| `auth status` | Show current authentication status     |
+| `auth logout` | Clear stored credentials               |
+| `sessions`   | List all connected sessions            |
+| `server`     | List all registered backend servers    |
+| `stop`       | Gracefully shut down the proxy         |
+| `help`       | Show available commands                |
 
 ---
 

--- a/proxy/src/main/java/me/internalizable/numdrassl/command/builtin/ServerCommand.java
+++ b/proxy/src/main/java/me/internalizable/numdrassl/command/builtin/ServerCommand.java
@@ -53,8 +53,6 @@ public class ServerCommand implements Command {
             return listServers(source, proxy);
         }
 
-        System.out.println("Args Length >> " + args.length);
-
         // Has target-player argument - transfer target to server
         if (args.length > 1) {
             // Find target player

--- a/proxy/src/main/java/me/internalizable/numdrassl/command/builtin/ServerCommand.java
+++ b/proxy/src/main/java/me/internalizable/numdrassl/command/builtin/ServerCommand.java
@@ -62,7 +62,7 @@ public class ServerCommand implements Command {
                         .red("[X] ")
                         .gray("Player is not online: ")
                         .red(args[1]));
-                return CommandResult.failure("Player is not online");
+                return CommandResult.success();
             }
 
             // Console OR player can execute this
@@ -75,7 +75,7 @@ public class ServerCommand implements Command {
             source.sendMessage(ChatMessageBuilder.create()
                     .red("[X] ")
                     .gray("Only players can switch servers."));
-            return CommandResult.failure("Only players can switch servers");
+            return CommandResult.success();
         }
 
         return transferToServerInternal(source, playerOpt.get(), proxy, args[0]);
@@ -154,7 +154,7 @@ public class ServerCommand implements Command {
             source.sendMessage(ChatMessageBuilder.create()
                     .red("[X] ")
                     .gray("Only players can switch servers."));
-            return CommandResult.failure("Only players can switch servers");
+            return CommandResult.success();
         }
 
         // Transfer the executing player
@@ -173,7 +173,7 @@ public class ServerCommand implements Command {
                     .gray("  Use ")
                     .yellow("/server")
                     .gray(" to see available servers."));
-            return CommandResult.failure("Unknown server: " + serverName);
+            return CommandResult.success();
         }
 
         RegisteredServer targetServer = serverOpt.get();
@@ -188,7 +188,7 @@ public class ServerCommand implements Command {
                     .gray(" is already connected to ")
                     .yellow(serverName)
                     .gray("."));
-            return CommandResult.failure("Target already connected to " + serverName);
+            return CommandResult.success();
         }
 
         // Inform the sender that the transfer is starting


### PR DESCRIPTION
Extend /server command to allow transferring other players

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
**Category** | Feature Enhancement / Command Extension  
**Impact (modules)** | proxy/src/main/java/me/internalizable/numdrassl/command/builtin/ServerCommand.java, README.md (Console Commands)  
**Summary** | Enhances the /server command to support transferring other players via usage "/server <server-name> [target-player]". No-args still lists servers. One-arg transfers the invoker (invoker must be a player). Two-args transfers the specified target player (can be invoked from console or by players). Transfer logic was refactored: transferToServerInternal(CommandSource, Player, ProxyServer, String) now validates server existence, checks current connection, notifies sender, initiates asynchronous transfer, and reports failures back to the sender. The README console command table was reformatted and the /server entry updated. Additionally, command execution now consistently returns a success CommandResult after handling (behavioral fix: "fix: return success after command execution").  
**Breaking Changes** | None that affect runtime behavior or public API signatures. The usage string changed ("/server <server-name> [target-player]"); tooling or scripts that parse help text may need to account for the new usage format.  
**Compatibility** | Backward-compatible: listing and single-argument self-transfer behavior remain (invoker-as-player requirement unchanged). The new two-argument form is additive and usable from console or players. No protocol or public API breaking changes introduced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->