### PR TITLE
fix: Fix colored chat output for players by resolving CommandSource correctly

### DIFF
--- a/api/src/main/java/me/internalizable/numdrassl/api/command/CommandSource.java
+++ b/api/src/main/java/me/internalizable/numdrassl/api/command/CommandSource.java
@@ -35,18 +35,23 @@ public interface CommandSource extends PermissionSubject {
      * @param builder the message builder
      */
     default void sendMessage(@Nonnull ChatMessageBuilder builder) {
-        if (this instanceof Player player) {
+        Optional<Player> playerOpt = this.asPlayer();
+
+        if (playerOpt.isPresent()) {
+            Player player = playerOpt.get();
             player.sendMessage(builder);
-        } else {
-            // Strip colors for console
-            StringBuilder sb = new StringBuilder();
-            for (FormattedMessagePart part : builder.getParts()) {
-                if (part.getText() != null) {
-                    sb.append(part.getText());
-                }
-            }
-            sendMessage(sb.toString());
+            return;
         }
+
+        // Console fallback: strip formatting and send plain text
+        StringBuilder sb = new StringBuilder();
+        for (FormattedMessagePart part : builder.getParts()) {
+            if (part.getText() != null) {
+                sb.append(part.getText());
+            }
+        }
+
+        sendMessage(sb.toString());
     }
 
     /**

--- a/api/src/main/java/me/internalizable/numdrassl/api/command/CommandSource.java
+++ b/api/src/main/java/me/internalizable/numdrassl/api/command/CommandSource.java
@@ -73,7 +73,7 @@ public interface CommandSource extends PermissionSubject {
      * @return true if this is a player
      */
     default boolean isPlayer() {
-        return this instanceof Player;
+        return this.asPlayer().isPresent();
     }
 
     /**


### PR DESCRIPTION
fix: Fix colored chat output for players by resolving CommandSource correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Bug Fix | api, proxy | sendMessage(ChatMessageBuilder) in CommandSource now resolves players via asPlayer() Optional and sends colored messages to Player instances; otherwise it falls back to a console path that strips formatting and sends plain text. asPlayer() uses an instanceof-backed default, isPlayer() now delegates to asPlayer().isPresent(), and isConsole() is provided as a default. | None | Backward compatible — new behavior is provided by default interface methods so existing implementations need no changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->