### PR TITLE
fix: Prevent proxy secret from being exposed via player commands

### DIFF
--- a/proxy/src/main/java/me/internalizable/numdrassl/command/builtin/AuthCommand.java
+++ b/proxy/src/main/java/me/internalizable/numdrassl/command/builtin/AuthCommand.java
@@ -1,5 +1,6 @@
 package me.internalizable.numdrassl.command.builtin;
 
+import me.internalizable.numdrassl.api.chat.ChatMessageBuilder;
 import me.internalizable.numdrassl.api.command.Command;
 import me.internalizable.numdrassl.api.command.CommandResult;
 import me.internalizable.numdrassl.api.command.CommandSource;
@@ -44,6 +45,13 @@ public class AuthCommand implements Command {
     @Override
     @Nonnull
     public CommandResult execute(@Nonnull CommandSource source, @Nonnull String[] args) {
+        if (source.isPlayer()) {
+            source.sendMessage(ChatMessageBuilder.create()
+                    .red("[X] ")
+                    .gray("This command can only be used from the console."));
+            return CommandResult.failure("This command can only be used from the console");
+        }
+
         if (args.length < 1) {
             source.sendMessage("Usage: " + getUsage());
             return CommandResult.success();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

**Security Fix** | **Command System (AuthCommand)** | 
Adds a pre-execution validation guard in `AuthCommand.execute()` that blocks player-initiated command execution by checking `source.isPlayer()`. If invoked by a player, the command returns a failure result with a user-friendly error message ("This command can only be used from the console") sent via `ChatMessageBuilder`. This guard executes before argument parsing, preventing access to sensitive subcommands like `secret` that would expose the Base64-encoded proxy secret to players. |
**No breaking changes to exported APIs** - the guard is internal to command execution flow and does not alter method signatures or public interface contracts. |
**Fully compatible** - the change is additive and only affects command authorization behavior. Console-based execution remains unaffected; players are simply denied access with appropriate feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->