### PR TITLE
Add GitHub Releases to Discord workflow

### DIFF
--- a/.github/workflows/github-releases-to-discord.yml
+++ b/.github/workflows/github-releases-to-discord.yml
@@ -1,0 +1,20 @@
+on:
+  release:
+    types: [published]
+
+jobs:
+  github-releases-to-discord:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: GitHub Releases to Discord
+        uses: SethCohen/github-releases-to-discord@v1
+        with:
+          webhook_url: ${{ secrets.WEBHOOK_URL }}
+          color: "2105893"
+          username: "Numdrassl Release Changelog"
+          avatar_url: "https://cdn.simna.app/bot_pfp.jpg"
+          content: "||@everyone||"
+          footer_title: "Changelog"
+          reduce_headings: true


### PR DESCRIPTION
This workflow triggers on published releases and sends notifications to a Discord channel.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

**Category:** GitHub Actions / CI-CD Integration

**Impact (modules):** Release notification system (GitHub Releases → Discord webhook)

**Summary:** Adds a new GitHub Actions workflow (`github-releases-to-discord.yml`) that automatically sends formatted release notifications to a Discord channel. The workflow triggers when a release is published, checks out the repository, and invokes the SethCohen/github-releases-to-discord action to post a styled message containing the release changelog. The notification is configured with a custom username ("Numdrassl Release Changelog"), avatar URL, color code (2105893), and content mentioning all Discord members (||@everyone||). The webhook URL is sourced from repository secrets for security.

**Breaking Changes:** None

**Compatibility:** Non-breaking, purely additive. The workflow does not affect existing code, functionality, or APIs. It requires a Discord webhook URL to be configured in repository secrets (WEBHOOK_URL) to function.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->