### PR TITLE
feat: add backend-initiated player transfers and PlayerTransferEvent

### DIFF
--- a/api/src/main/java/me/internalizable/numdrassl/api/chat/ChatMessageBuilder.java
+++ b/api/src/main/java/me/internalizable/numdrassl/api/chat/ChatMessageBuilder.java
@@ -272,6 +272,25 @@ public final class ChatMessageBuilder {
         );
     }
 
+    /**
+     * Returns the plain text content without any formatting.
+     *
+     * <p>Useful for logging or when a plain text representation is needed.</p>
+     *
+     * @return the concatenated text of all parts
+     */
+    @Nonnull
+    public String toPlainText() {
+        StringBuilder sb = new StringBuilder();
+        for (FormattedMessagePart part : parts) {
+            String text = part.getText();
+            if (text != null) {
+                sb.append(text);
+            }
+        }
+        return sb.toString();
+    }
+
     // ==================== Internal ====================
 
     private FormattedMessagePart createPart(

--- a/api/src/main/java/me/internalizable/numdrassl/api/event/player/PlayerTransferEvent.java
+++ b/api/src/main/java/me/internalizable/numdrassl/api/event/player/PlayerTransferEvent.java
@@ -1,0 +1,180 @@
+package me.internalizable.numdrassl.api.event.player;
+
+import me.internalizable.numdrassl.api.chat.ChatMessageBuilder;
+import me.internalizable.numdrassl.api.event.ResultedEvent;
+import me.internalizable.numdrassl.api.player.Player;
+import me.internalizable.numdrassl.api.server.RegisteredServer;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Event fired when a player is being transferred to another server.
+ *
+ * <p>This event is triggered for all transfer types:</p>
+ * <ul>
+ *   <li>Backend-initiated transfers (via ClientReferral)</li>
+ *   <li>Proxy-initiated transfers (via commands or API)</li>
+ * </ul>
+ *
+ * <p>Plugins can use this event to:</p>
+ * <ul>
+ *   <li>Cancel the transfer</li>
+ *   <li>Redirect the player to a different server</li>
+ *   <li>Log or audit transfer attempts</li>
+ *   <li>Apply custom transfer logic based on conditions</li>
+ * </ul>
+ *
+ * <p>Example usage:</p>
+ * <pre>{@code
+ * @Subscribe
+ * public void onPlayerTransfer(PlayerTransferEvent event) {
+ *     if (event.getTargetServer().getName().equals("maintenance")) {
+ *         event.setResult(PlayerTransferEvent.PlayerTransferResult.denied("Server under maintenance"));
+ *     }
+ * }
+ * }</pre>
+ */
+public class PlayerTransferEvent implements ResultedEvent<PlayerTransferEvent.PlayerTransferResult> {
+
+    private final Player player;
+    private final RegisteredServer currentServer;
+    private final RegisteredServer targetServer;
+    private PlayerTransferResult result;
+
+    public PlayerTransferEvent(
+            @Nonnull Player player,
+            @Nullable RegisteredServer currentServer,
+            @Nonnull RegisteredServer targetServer) {
+        this.player = player;
+        this.currentServer = currentServer;
+        this.targetServer = targetServer;
+        this.result = PlayerTransferResult.allowed(targetServer);
+    }
+
+    /**
+     * Get the player being transferred.
+     *
+     * @return the player
+     */
+    @Nonnull
+    public Player getPlayer() {
+        return player;
+    }
+
+    /**
+     * Get the server the player is currently connected to, if any.
+     *
+     * @return the current server, or empty if not connected
+     */
+    @Nonnull
+    public Optional<RegisteredServer> getCurrentServer() {
+        return Optional.ofNullable(currentServer);
+    }
+
+    /**
+     * Get the server that was originally requested as the transfer target.
+     *
+     * @return the original target server
+     */
+    @Nonnull
+    public RegisteredServer getTargetServer() {
+        return targetServer;
+    }
+
+    @Override
+    public PlayerTransferResult getResult() {
+        return result;
+    }
+
+    @Override
+    public void setResult(PlayerTransferResult result) {
+        this.result = result;
+    }
+
+    /**
+     * Result for a player transfer event.
+     */
+    public static final class PlayerTransferResult implements Result {
+
+        private static final PlayerTransferResult DENIED = new PlayerTransferResult(false, null, null);
+
+        private final boolean allowed;
+        private final RegisteredServer server;
+        private final ChatMessageBuilder denyMessage;
+
+        private PlayerTransferResult(boolean allowed, @Nullable RegisteredServer server, @Nullable ChatMessageBuilder denyMessage) {
+            this.allowed = allowed;
+            this.server = server;
+            this.denyMessage = denyMessage;
+        }
+
+        @Override
+        public boolean isAllowed() {
+            return allowed;
+        }
+
+        /**
+         * Get the server to transfer to.
+         *
+         * @return the target server, or null if denied
+         */
+        @Nullable
+        public RegisteredServer getServer() {
+            return server;
+        }
+
+        /**
+         * Get the denial message.
+         *
+         * @return the deny message, or null if allowed or silent denial
+         */
+        @Nullable
+        public ChatMessageBuilder getDenyMessage() {
+            return denyMessage;
+        }
+
+        /**
+         * Allow the transfer to the specified server.
+         *
+         * @param server the server to transfer to
+         * @return an allowed result
+         */
+        public static PlayerTransferResult allowed(@Nonnull RegisteredServer server) {
+            return new PlayerTransferResult(true, server, null);
+        }
+
+        /**
+         * Deny the transfer silently (no message shown to player).
+         *
+         * @return a denied result without message
+         */
+        public static PlayerTransferResult denied() {
+            return DENIED;
+        }
+
+        /**
+         * Deny the transfer with a plain text reason.
+         *
+         * @param reason the reason to show the player
+         * @return a denied result
+         */
+        public static PlayerTransferResult denied(@Nonnull String reason) {
+            Objects.requireNonNull(reason, "reason");
+            return new PlayerTransferResult(false, null, ChatMessageBuilder.create().white(reason));
+        }
+
+        /**
+         * Deny the transfer with a formatted message.
+         *
+         * @param message the formatted message to show the player
+         * @return a denied result
+         */
+        public static PlayerTransferResult denied(@Nonnull ChatMessageBuilder message) {
+            Objects.requireNonNull(message, "message");
+            return new PlayerTransferResult(false, null, message);
+        }
+    }
+}

--- a/docs/PLUGIN_DEVELOPMENT.md
+++ b/docs/PLUGIN_DEVELOPMENT.md
@@ -256,6 +256,7 @@ Priorities (in order): `FIRST` → `EARLY` → `NORMAL` → `LATE` → `LAST`
 | Event | Description | Cancellable |
 |-------|-------------|-------------|
 | `PreLoginEvent` | Before authentication, only IP known | Yes |
+| `AsyncLoginEvent` | Async login phase for non-blocking I/O (database, API calls) | Yes |
 | `LoginEvent` | During authentication, player info known | Yes |
 | `PostLoginEvent` | After successful authentication | No |
 | `DisconnectEvent` | Player disconnected | No |
@@ -268,6 +269,7 @@ Priorities (in order): `FIRST` → `EARLY` → `NORMAL` → `LATE` → `LAST`
 | `PlayerMoveEvent` | Player moves | Yes |
 | `PlayerBlockPlaceEvent` | Player places block | Yes |
 | `PlayerSlotChangeEvent` | Player changes hotbar slot | No |
+| `PlayerTransferEvent` | Player is being transferred to another server | Yes (can redirect) |
 
 #### Server Events
 | Event | Description | Cancellable |
@@ -325,6 +327,134 @@ public void onBlockPlace(PlayerBlockPlaceEvent event) {
     }
 }
 ```
+
+### Async Login (Database/API Loading)
+
+Use `AsyncLoginEvent` to perform non-blocking I/O operations during login without freezing the proxy. This is the correct place to load player data from databases, external APIs, or any heavy operation:
+
+```java
+import me.internalizable.numdrassl.api.event.Subscribe;
+import me.internalizable.numdrassl.api.event.connection.AsyncLoginEvent;
+
+import java.util.concurrent.CompletableFuture;
+
+public class MyListener {
+
+    @Subscribe
+    public void onAsyncLogin(AsyncLoginEvent event) {
+        // Create async task for database loading
+        CompletableFuture<Void> dbTask = CompletableFuture.runAsync(() -> {
+            User user = database.load(event.getPlayer().getUniqueId());
+
+            if (user.isBanned()) {
+                event.setResult(AsyncLoginEvent.AsyncLoginResult.denied("You are banned!"));
+            }
+        });
+
+        // Register task — proxy waits for completion before proceeding
+        event.registerTask(dbTask);
+    }
+}
+```
+
+**How it works:**
+- The event is fired synchronously, but plugins register `CompletableFuture` tasks
+- The proxy waits for **all** registered tasks to complete before proceeding with the login
+- Multiple plugins can each register their own tasks — all run in parallel
+- If any task calls `setResult(denied(...))`, the player is disconnected
+
+**Use this for:** database lookups, permission loading, ban checks, API calls, or any I/O that would block the proxy if done synchronously.
+
+### Transfer Interception
+
+Use `PlayerTransferEvent` to intercept, deny, or redirect player transfers. This event fires for all transfer types: backend-initiated transfers (via `referToServer()`), proxy commands, and API calls.
+
+```java
+import me.internalizable.numdrassl.api.event.Subscribe;
+import me.internalizable.numdrassl.api.event.player.PlayerTransferEvent;
+import me.internalizable.numdrassl.api.chat.ChatMessageBuilder;
+
+public class MyListener {
+
+    @Subscribe
+    public void onPlayerTransfer(PlayerTransferEvent event) {
+        var player = event.getPlayer();
+        var target = event.getTargetServer();
+
+        // Prevent transferring to the same server
+        event.getCurrentServer().ifPresent(current -> {
+            if (current.getName().equals(target.getName())) {
+                event.setResult(PlayerTransferEvent.PlayerTransferResult.denied(
+                    ChatMessageBuilder.create().red("You are already on this server!")
+                ));
+            }
+        });
+    }
+}
+```
+
+**Deny with permission check:**
+
+```java
+@Subscribe
+public void onPlayerTransfer(PlayerTransferEvent event) {
+    var target = event.getTargetServer();
+
+    if (target.getName().startsWith("vip-") && !event.getPlayer().hasPermission("server.vip")) {
+        event.setResult(PlayerTransferEvent.PlayerTransferResult.denied(
+            ChatMessageBuilder.create()
+                .red("[X] ")
+                .gray("You need ")
+                .gold("VIP")
+                .gray(" rank to access this server!")
+        ));
+    }
+}
+```
+
+**Redirect to load-balanced server:**
+
+```java
+@Subscribe
+public void onPlayerTransfer(PlayerTransferEvent event) {
+    if (event.getTargetServer().getName().equals("lobby")) {
+        String bestLobby = findLeastLoadedLobby();
+        proxy.getServer(bestLobby).ifPresent(server -> {
+            event.setResult(PlayerTransferEvent.PlayerTransferResult.allowed(server));
+        });
+    }
+}
+```
+
+**Silent denial:**
+
+```java
+@Subscribe
+public void onPlayerTransfer(PlayerTransferEvent event) {
+    if (isServerUnderMaintenance(event.getTargetServer().getName())) {
+        event.setResult(PlayerTransferEvent.PlayerTransferResult.denied());
+    }
+}
+```
+
+**API Reference:**
+
+| `PlayerTransferEvent` Method | Description |
+|------------------------------|-------------|
+| `getPlayer()` | The player being transferred |
+| `getCurrentServer()` | `Optional<RegisteredServer>` — current server (if connected) |
+| `getTargetServer()` | The requested target server |
+| `getResult()` | Current transfer result |
+| `setResult(PlayerTransferResult)` | Set the transfer result |
+
+| `PlayerTransferResult` Factory | Description |
+|-------------------------------|-------------|
+| `allowed(RegisteredServer)` | Allow transfer (optionally redirect to different server) |
+| `denied()` | Deny silently (no message shown) |
+| `denied(String)` | Deny with plain text message |
+| `denied(ChatMessageBuilder)` | Deny with formatted message |
+
+> **Note:** This event is synchronous. All player data should be loaded during `AsyncLoginEvent` and kept in memory during the session. Avoid database queries or heavy I/O inside this event handler.
 
 ---
 

--- a/proxy/src/main/java/me/internalizable/numdrassl/pipeline/BackendPacketHandler.java
+++ b/proxy/src/main/java/me/internalizable/numdrassl/pipeline/BackendPacketHandler.java
@@ -1,6 +1,7 @@
 package me.internalizable.numdrassl.pipeline;
 
 import com.hypixel.hytale.protocol.Packet;
+import com.hypixel.hytale.protocol.packets.auth.ClientReferral;
 import com.hypixel.hytale.protocol.packets.auth.ConnectAccept;
 import com.hypixel.hytale.protocol.packets.connection.Disconnect;
 import io.netty.buffer.ByteBuf;
@@ -14,7 +15,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
 
 /**
  * Handles packets from the upstream backend server.
@@ -26,6 +30,14 @@ import java.util.Objects;
 public final class BackendPacketHandler extends SimpleChannelInboundHandler<Object> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(BackendPacketHandler.class);
+
+    /**
+     * Magic marker identifying backend-initiated transfers via ClientReferral.
+     * When a backend sends this marker in the referral data, the proxy intercepts
+     * and handles the transfer instead of forwarding to the client.
+     * Pre-computed as byte[] to avoid String allocation per packet.
+     */
+    private static final byte[] BACKEND_TRANSFER_MARKER = "Numdrassl".getBytes(StandardCharsets.UTF_8);
 
     private final ProxyCore proxyCore;
     private final ProxySession session;
@@ -68,6 +80,8 @@ public final class BackendPacketHandler extends SimpleChannelInboundHandler<Obje
             handleConnectAccept(accept);
         } else if (packet instanceof Disconnect disconnect) {
             handleDisconnect(disconnect);
+        } else if (packet instanceof ClientReferral referral) {
+            handleClientReferral(referral);
         } else {
             forwardToClient(packet);
         }
@@ -119,6 +133,46 @@ public final class BackendPacketHandler extends SimpleChannelInboundHandler<Obje
 
         forwardToClient(disconnect);
         session.disconnect("Backend disconnected: " + disconnect.reason);
+    }
+
+    private void handleClientReferral(ClientReferral referral) {
+        if (isBackendInitiatedTransfer(referral.data)) {
+            handleBackendInitiatedTransfer(referral);
+            return;
+        }
+
+        // External referral - forward to client (original behavior)
+        LOGGER.debug("Session {}: Forwarding external ClientReferral to client", session.getSessionId());
+        forwardToClient(referral);
+    }
+
+    private boolean isBackendInitiatedTransfer(byte[] data) {
+        return data != null && Arrays.equals(data, BACKEND_TRANSFER_MARKER);
+    }
+
+    private void handleBackendInitiatedTransfer(ClientReferral referral) {
+        if (referral.hostTo == null) {
+            LOGGER.warn("Session {}: Invalid ClientReferral missing destination", session.getSessionId());
+            return;
+        }
+
+        // Early validation — avoid unnecessary work if session is not in a transferable state
+        if (session.isServerTransfer() || session.getState() != SessionState.CONNECTED) {
+            LOGGER.debug("Session {}: Ignoring backend transfer request (state={}, serverTransfer={})",
+                    session.getSessionId(), session.getState(), session.isServerTransfer());
+            return;
+        }
+
+        String targetServerName = referral.hostTo.host;
+
+        LOGGER.info("Session {}: Backend {} requested transfer to {}",
+                session.getSessionId(), Objects.requireNonNull(session.getCurrentBackend()).getName(), targetServerName);
+
+        // Dispatch off the Netty event loop to avoid blocking I/O for other sessions.
+        // PlayerTransfer.transfer() fires PlayerTransferEvent synchronously — with mass transfers
+        // (e.g. 2000 referToServer() in a loop), this would block the event loop thread for all
+        // synchronous event handler executions if run inline.
+        CompletableFuture.runAsync(() -> proxyCore.getPlayerTransfer().transfer(session, targetServerName));
     }
 
     private boolean isTransferring() {

--- a/proxy/src/main/java/me/internalizable/numdrassl/plugin/bridge/ApiEventBridge.java
+++ b/proxy/src/main/java/me/internalizable/numdrassl/plugin/bridge/ApiEventBridge.java
@@ -87,6 +87,20 @@ public final class ApiEventBridge implements PacketListener {
         lifecycleHandler.onPostLogin(session);
     }
 
+    /**
+     * Fires PlayerTransferEvent before a player transfer.
+     *
+     * @param session the player session
+     * @param targetBackend the requested target backend
+     * @return the result containing the final target, or denial reason
+     */
+    @Nonnull
+    public PlayerTransferBridgeResult firePlayerTransferEvent(
+            @Nonnull ProxySession session,
+            @Nonnull BackendServer targetBackend) {
+        return lifecycleHandler.onPlayerTransfer(session, targetBackend);
+    }
+
     // ==================== Accessors ====================
 
     /**

--- a/proxy/src/main/java/me/internalizable/numdrassl/plugin/bridge/PlayerTransferBridgeResult.java
+++ b/proxy/src/main/java/me/internalizable/numdrassl/plugin/bridge/PlayerTransferBridgeResult.java
@@ -1,0 +1,64 @@
+package me.internalizable.numdrassl.plugin.bridge;
+
+import me.internalizable.numdrassl.api.chat.ChatMessageBuilder;
+import me.internalizable.numdrassl.config.BackendServer;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.Objects;
+
+/**
+ * Internal result of firing a PlayerTransferEvent.
+ *
+ * <p>This record bridges the API event result to the internal proxy
+ * representation using {@link BackendServer}.</p>
+ *
+ * @param allowed whether the transfer is allowed
+ * @param targetServer the target backend server (may be redirected)
+ * @param denyMessage the denial message if not allowed
+ */
+public record PlayerTransferBridgeResult(
+    boolean allowed,
+    @Nullable BackendServer targetServer,
+    @Nullable ChatMessageBuilder denyMessage
+) {
+    /**
+     * Creates an allowed result with the given target server.
+     */
+    @Nonnull
+    public static PlayerTransferBridgeResult allow(@Nonnull BackendServer targetServer) {
+        Objects.requireNonNull(targetServer, "targetServer");
+        return new PlayerTransferBridgeResult(true, targetServer, null);
+    }
+
+    /**
+     * Creates a denied result with the given message.
+     */
+    @Nonnull
+    public static PlayerTransferBridgeResult deny(@Nullable ChatMessageBuilder message) {
+        return new PlayerTransferBridgeResult(false, null, message);
+    }
+
+    /**
+     * Creates a redirected result to a different server.
+     */
+    @Nonnull
+    public static PlayerTransferBridgeResult redirect(@Nonnull BackendServer newTarget) {
+        Objects.requireNonNull(newTarget, "newTarget");
+        return new PlayerTransferBridgeResult(true, newTarget, null);
+    }
+
+    public boolean isAllowed() {
+        return allowed;
+    }
+
+    @Nullable
+    public BackendServer getTargetServer() {
+        return targetServer;
+    }
+
+    @Nullable
+    public ChatMessageBuilder getDenyMessage() {
+        return denyMessage;
+    }
+}


### PR DESCRIPTION
## Summary

Adds support for **backend-initiated player transfers** using the native Hytale `PlayerRef.referToServer()` API, and introduces `PlayerTransferEvent` allowing proxy plugins to intercept, deny, redirect, or audit all transfer requests.

## New Features

### 1. Backend-Initiated Player Transfers

Backend server plugins can now transfer players to other servers through the proxy using the native Hytale API:

```java
// In your Hytale server plugin
playerRef.referToServer("lobby", 25565, "Numdrassl".getBytes(StandardCharsets.UTF_8));
```

The proxy intercepts `ClientReferral` packets with the `"Numdrassl"` marker and handles the transfer internally.

### 2. PlayerTransferEvent

New event that fires for **all** player transfers (backend-initiated and proxy-initiated), allowing plugins to:

- Deny transfers with custom formatted messages
- Redirect players to different servers
- Implement permission checks, cooldowns, or custom logic
- Audit/log transfer attempts

---

## Transfer Flow

```
┌─────────────────────────────────────────────────────────────────┐
│                                                                  │
│  Backend Server (Hytale Plugin)         Proxy Command/API       │
│           │                                    │                 │
│           │ playerRef.referToServer(           │ player.transfer │
│           │   "lobby", 25565,                  │   ("lobby");    │
│           │   "Numdrassl".getBytes()           │                 │
│           │ );                                 │                 │
│           │                                    │                 │
│           ▼                                    ▼                 │
│  ┌─────────────────────────────────────────────────────────┐    │
│  │              PlayerTransfer.transfer()                   │    │
│  │              (Central entry point)                       │    │
│  └────────────────────────┬────────────────────────────────┘    │
│                           │                                      │
│                           ▼                                      │
│  ┌─────────────────────────────────────────────────────────┐    │
│  │              Fire PlayerTransferEvent                    │    │
│  │              (Plugins can intercept)                     │    │
│  └────────────────────────┬────────────────────────────────┘    │
│                           │                                      │
│              ┌────────────┴────────────┐                         │
│              ▼                         ▼                         │
│       Plugin Denied              Plugin Allowed                  │
│              │                         │                         │
│              ▼                         ▼                         │
│       Send message to           Execute transfer                 │
│       player & return                                            │
│                                                                  │
└─────────────────────────────────────────────────────────────────┘
```

---

## Usage: Backend Server Plugin (Hytale)

```java
import com.hypixel.hytale.server.core.universe.PlayerRef;
import java.nio.charset.StandardCharsets;

public class MyServerPlugin {

    private static final byte[] NUMDRASSL_MARKER = "Numdrassl".getBytes(StandardCharsets.UTF_8);

    // Transfer player to lobby
    public void sendToLobby(PlayerRef player) {
        player.referToServer("lobby", 25565, NUMDRASSL_MARKER);
    }

    // Transfer player to a minigame server
    public void sendToMinigame(PlayerRef player, String gameType) {
        player.referToServer("minigame-" + gameType, 25565, NUMDRASSL_MARKER);
    }

    // Transfer player after game ends
    public void onGameEnd(PlayerRef player) {
        player.referToServer("lobby", 25565, NUMDRASSL_MARKER);
    }
}
```

**Notes:**
- The `host` parameter is the server name configured in proxy's `config.yml`
- The `port` parameter is ignored by the proxy (use any valid port)
- The `"Numdrassl"` marker identifies this as an internal proxy transfer

---

## Usage: Proxy Plugin (Numdrassl)

### Deny with Permission Check

```java
@Subscribe
public void onPlayerTransfer(PlayerTransferEvent event) {
    var player = event.getPlayer();
    var target = event.getTargetServer();

    if (target.getName().startsWith("vip-") && !player.hasPermission("server.vip")) {
        event.setResult(PlayerTransferResult.denied(
            ChatMessageBuilder.create()
                .red("[X] ")
                .gray("You need ")
                .gold("VIP")
                .gray(" rank to access this server!")
        ));
    }
}
```

### Redirect to Load-Balanced Server

```java
@Subscribe
public void onPlayerTransfer(PlayerTransferEvent event) {
    if (event.getTargetServer().getName().equals("lobby")) {
        String bestLobby = findLeastLoadedLobby();
        proxy.getServer(bestLobby).ifPresent(server -> {
            event.setResult(PlayerTransferResult.allowed(server));
        });
    }
}
```

### Silent Denial

```java
@Subscribe
public void onPlayerTransfer(PlayerTransferEvent event) {
    if (isPlayerBanned(event.getPlayer(), event.getTargetServer().getName())) {
        // Deny without message - handle messaging yourself
        event.setResult(PlayerTransferResult.denied());
    }
}
```

### Cooldown Between Transfers

```java
private final Map<UUID, Long> lastTransfer = new ConcurrentHashMap<>();
private static final long COOLDOWN_MS = 3000;

@Subscribe
public void onPlayerTransfer(PlayerTransferEvent event) {
    var player = event.getPlayer();
    var now = System.currentTimeMillis();

    Long last = lastTransfer.get(player.getUniqueId());
    if (last != null && (now - last) < COOLDOWN_MS) {
        event.setResult(PlayerTransferResult.denied(
            ChatMessageBuilder.create()
                .red("[!] ")
                .gray("Please wait before transferring again.")
        ));
        return;
    }

    lastTransfer.put(player.getUniqueId(), now);
}
```

---

## API Reference

### PlayerTransferEvent

| Method | Description |
|--------|-------------|
| `getPlayer()` | The player being transferred |
| `getCurrentServer()` | `Optional<RegisteredServer>` - Current server (if connected) |
| `getTargetServer()` | The requested target server |
| `getResult()` | Current transfer result |
| `setResult(PlayerTransferResult)` | Set the transfer result |

### PlayerTransferResult

| Method | Description |
|--------|-------------|
| `allowed(RegisteredServer)` | Allow transfer (optionally redirect) |
| `denied()` | Deny silently (no message) |
| `denied(String)` | Deny with plain text message |
| `denied(ChatMessageBuilder)` | Deny with formatted message |

---

## Files Changed

- **New:** `api/event/player/PlayerTransferEvent.java`
- **New:** `proxy/plugin/bridge/PlayerTransferBridgeResult.java`
- **Modified:** `proxy/server/transfer/PlayerTransfer.java` - Fire event before transfer
- **Modified:** `proxy/pipeline/BackendPacketHandler.java` - Handle backend transfers
- **Modified:** `proxy/plugin/bridge/SessionLifecycleHandler.java` - Process event
- **Modified:** `proxy/plugin/bridge/ApiEventBridge.java` - Expose event firing
- **Modified:** `api/chat/ChatMessageBuilder.java` - Added `toPlainText()` method

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Category | Event System & Transfer Mechanism  
Impact (modules) | API (event + chat), Proxy Plugin Bridge, Proxy Core (packet handling, transfer orchestration, session lifecycle), Documentation (README, plugin guide)

Summary | Adds backend-initiated player transfers and a pluggable transfer event flow. Backends can initiate transfers using Hytale’s PlayerRef.referToServer() by sending ClientReferral packets with a special marker token (NUMDRASSL_MARKER / "Numdrassl"). BackendPacketHandler inspects ClientReferral payloads: referrals containing the marker are treated as backend-initiated and handled internally (the referral host string is used as the configured backend name and the supplied port is ignored); referrals without the marker are forwarded to the client unchanged. Core transfer orchestration is centralized in PlayerTransfer.transfer(...) (new overload that accepts a backend name), which fires the new PlayerTransferEvent before executing any transfer. Plugins can intercept the event and return PlayerTransferResult to allow (optionally redirect to a different RegisteredServer/BackendServer), deny silently, or deny with a message (plain or formatted). Bridge and lifecycle plumbing translate API results to proxy internals: ApiEventBridge.firePlayerTransferEvent, SessionLifecycleHandler.onPlayerTransfer, and the PlayerTransferBridgeResult record. PlayerTransfer now consults BackendHealthCache/backend connector to validate backend availability before completing transfers and logs/returns TransferResult appropriately. ChatMessageBuilder.toPlainText() was added to render denial messages for TransferResult. Documentation updated with examples for backend-initiated transfers, AsyncLoginEvent, and transfer interception.

Breaking Changes | None. Additive API and behavior; default transfer behavior unchanged when no plugin intervenes. The proxy now reserves referral payloads containing the configured marker for internal transfer handling—if a backend wishes referral to be forwarded to the client it must not include the marker.

Compatibility | Backward compatible. Existing client- and proxy-initiated transfers continue to work. Plugins can opt into transfer interception via PlayerTransferEvent. Protocol notes: ClientReferral packets are parsed for the marker string; when present the proxy treats the host field as a backend lookup key (ignoring the port) and handles the transfer internally off the Netty event loop; referrals lacking the marker are passed through to clients as before.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->