### PR TITLE
feat: implement host-based routing for backend servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ A BungeeCord/Velocity-style proxy server for Hytale, built using Netty QUIC. All
 ### Core Functionality
 - **QUIC Protocol Support** - Native QUIC transport with BBR congestion control for low-latency connections
 - **Multi-Backend Support** - Route players to different backend servers (lobby, minigames, etc.)
+- **Host-Based Routing** - Route players to specific backends based on hostname/SNI (e.g., play.example.com → lobby, survival.example.com → survival)
 - **Player Transfer** - Seamless server switching via `/server` command
 - **Packet Interception** - Decode, inspect, modify, or cancel packets in transit
 
@@ -127,6 +128,26 @@ See [Backend Server Setup](#backend-server-setup-bridge) for detailed instructio
 
 ## Configuration
 
+### Host-Based Routing
+
+Numdrassl supports routing players to different backend servers based on the hostname they connect with (SNI). This allows you to have multiple hostnames pointing to the same proxy IP, with each routing to a different backend.
+
+**Example Setup:**
+- `play.example.com` → routes to `lobby` backend
+- `survival.example.com` → routes to `survival` backend
+- `minigames.example.com` → routes to `minigames` backend
+
+**DNS Configuration:**
+```
+play.example.com      A    192.168.1.50
+survival.example.com  A    192.168.1.50
+minigames.example.com A    192.168.1.50
+```
+
+All three hostnames point to the same proxy IP (`192.168.1.50`), but the proxy routes each to its configured backend based on the SNI hostname sent during the TLS handshake.
+
+**Note:** Host-based routing requires SNI (Server Name Indication) support. Most modern clients send SNI automatically. If SNI is not available, connections fall back to the default backend.
+
 ### Proxy Configuration (`config/proxy.yml`)
 
 ```yaml
@@ -174,19 +195,25 @@ proxySecret: "your-shared-secret-here"
 # ==================== Backend Servers ====================
 
 # List of backend servers players can connect to
+# hostname: Optional hostname/SNI for host-based routing
+#           If set, connections with this hostname route to this backend
+#           Example: play.example.com -> lobby, survival.example.com -> survival
 backends:
   - name: "lobby"
     host: "127.0.0.1"
     port: 5520
     defaultServer: true
+    hostname: "play.example.com"  # Optional: route play.example.com to lobby
   - name: "survival"
     host: "192.168.1.100"
     port: 5520
     defaultServer: false
+    hostname: "survival.example.com"  # Optional: route survival.example.com to survival
   - name: "minigames"
     host: "192.168.1.101"
     port: 5520
     defaultServer: false
+    # No hostname set - only accessible via /server command or default fallback
 
 # ==================== Metrics Configuration ====================
 

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Numdrassl supports routing players to different backend servers based on the hos
 - `minigames.example.com` → routes to `minigames` backend
 
 **DNS Configuration:**
-```
+```text
 play.example.com      A    192.168.1.50
 survival.example.com  A    192.168.1.50
 minigames.example.com A    192.168.1.50

--- a/proxy/src/main/java/me/internalizable/numdrassl/auth/SniExtractor.java
+++ b/proxy/src/main/java/me/internalizable/numdrassl/auth/SniExtractor.java
@@ -1,0 +1,125 @@
+package me.internalizable.numdrassl.auth;
+
+import io.netty.incubator.codec.quic.QuicChannel;
+import io.netty.util.AttributeKey;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.net.ssl.SSLEngine;
+import java.util.Objects;
+
+/**
+ * Utility for extracting SNI (Server Name Indication) from QUIC/TLS connections.
+ *
+ * <p>SNI allows clients to specify which hostname they're connecting to during
+ * the TLS handshake, enabling host-based routing on the proxy.</p>
+ *
+ * <p><b>Note:</b> SNI extraction in QUIC/TLS requires proper SSL context configuration.
+ * The proxy must be configured to capture SNI during the handshake. This implementation
+ * attempts to extract SNI from various sources, but may return null if SNI is not
+ * available or not properly configured.</p>
+ */
+public final class SniExtractor {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SniExtractor.class);
+
+    /**
+     * Attribute key for storing SNI hostname in QUIC channels.
+     * This is set by Netty's SNI handler during the TLS handshake.
+     */
+    private static final AttributeKey<String> SNI_HOSTNAME_KEY = AttributeKey.valueOf("SNI_HOSTNAME");
+
+    private SniExtractor() {
+        // Utility class
+    }
+
+    /**
+     * Extracts the SNI hostname from a QUIC channel.
+     *
+     * <p>This method attempts to extract the hostname that the client specified
+     * during the TLS handshake. Returns null if SNI is not available or not provided.</p>
+     *
+     * <p><b>Note:</b> SNI extraction requires the TLS handshake to be completed or in progress.
+     * If called too early, this method may return null even if SNI was provided.</p>
+     *
+     * <p>Extraction methods (in order):</p>
+     * <ol>
+     *   <li>Channel attribute (set by SNI handler during handshake)</li>
+     *   <li>Netty's standard SNI attribute</li>
+     *   <li>SSL session peer host (may not be reliable for server-side SNI)</li>
+     * </ol>
+     *
+     * @param channel the QUIC channel (handshake may be in progress or completed)
+     * @return the SNI hostname, or null if not available
+     */
+    @Nullable
+    public static String extractHostname(@Nonnull QuicChannel channel) {
+        Objects.requireNonNull(channel, "channel");
+
+        try {
+            // Method 1: Check channel attribute (set by SNI handler during handshake)
+            String hostname = channel.attr(SNI_HOSTNAME_KEY).get();
+            if (hostname != null && !hostname.isEmpty()) {
+                LOGGER.debug("Extracted hostname from channel attribute: {}", hostname);
+                return hostname;
+            }
+
+            // Method 2: Try Netty's standard SNI attribute
+            try {
+                AttributeKey<String> nettySniKey = AttributeKey.valueOf("io.netty.handler.ssl.SNI_HOSTNAME");
+                String nettyHostname = channel.attr(nettySniKey).get();
+                if (nettyHostname != null && !nettyHostname.isEmpty()) {
+                    LOGGER.debug("Extracted hostname from Netty SNI attribute: {}", nettyHostname);
+                    return nettyHostname;
+                }
+            } catch (Exception e) {
+                // Attribute key might not exist, continue to next method
+            }
+
+            // Method 3: Try SSL session peer host (less reliable for server-side SNI)
+            // Note: This may not work reliably as peerHost is typically set by the client
+            // for client-side connections, not server-side SNI extraction
+            SSLEngine sslEngine = channel.sslEngine();
+            if (sslEngine != null) {
+                try {
+                    javax.net.ssl.SSLSession session = sslEngine.getSession();
+                    if (session != null) {
+                        String peerHost = session.getPeerHost();
+                        // Only use if it looks like a hostname (contains dots, not an IP)
+                        if (peerHost != null && !peerHost.isEmpty() && 
+                            !peerHost.equals("null") && peerHost.contains(".") &&
+                            !peerHost.matches("^\\d+\\.\\d+\\.\\d+\\.\\d+$")) {
+                            LOGGER.debug("Extracted hostname from SSL session peer host: {}", peerHost);
+                            return peerHost;
+                        }
+                    }
+                } catch (Exception e) {
+                    // SSL session might not be ready yet
+                    LOGGER.debug("SSL session not ready for SNI extraction: {}", e.getMessage());
+                }
+            }
+
+            return null;
+
+        } catch (Exception e) {
+            LOGGER.debug("Failed to extract SNI hostname: {}", e.getMessage());
+            return null;
+        }
+    }
+
+    /**
+     * Sets the SNI hostname in a channel attribute.
+     * This is typically called by an SNI handler during the TLS handshake.
+     *
+     * @param channel the QUIC channel
+     * @param hostname the SNI hostname
+     */
+    public static void setHostname(@Nonnull QuicChannel channel, @Nonnull String hostname) {
+        Objects.requireNonNull(channel, "channel");
+        Objects.requireNonNull(hostname, "hostname");
+        channel.attr(SNI_HOSTNAME_KEY).set(hostname);
+        LOGGER.debug("Set SNI hostname in channel: {}", hostname);
+    }
+}

--- a/proxy/src/main/java/me/internalizable/numdrassl/config/BackendServer.java
+++ b/proxy/src/main/java/me/internalizable/numdrassl/config/BackendServer.java
@@ -22,10 +22,7 @@ public class BackendServer {
     }
 
     public BackendServer(String name, String host, int port, boolean defaultServer, String hostname) {
-        this.name = name;
-        this.host = host;
-        this.port = port;
-        this.defaultServer = defaultServer;
+        this(name, host, port, defaultServer);
         this.hostname = hostname;
     }
 

--- a/proxy/src/main/java/me/internalizable/numdrassl/config/BackendServer.java
+++ b/proxy/src/main/java/me/internalizable/numdrassl/config/BackendServer.java
@@ -9,6 +9,7 @@ public class BackendServer {
     private String host;
     private int port;
     private boolean defaultServer;
+    private String hostname; // Optional: hostname/SNI to route to this backend
 
     public BackendServer() {
     }
@@ -18,6 +19,14 @@ public class BackendServer {
         this.host = host;
         this.port = port;
         this.defaultServer = defaultServer;
+    }
+
+    public BackendServer(String name, String host, int port, boolean defaultServer, String hostname) {
+        this.name = name;
+        this.host = host;
+        this.port = port;
+        this.defaultServer = defaultServer;
+        this.hostname = hostname;
     }
 
     public String getName() {
@@ -52,14 +61,46 @@ public class BackendServer {
         this.defaultServer = defaultServer;
     }
 
+    /**
+     * Gets the hostname/SNI that routes to this backend.
+     * If set, connections with this hostname will be routed to this backend.
+     *
+     * @return the hostname, or null if not set
+     */
+    public String getHostname() {
+        return hostname;
+    }
+
+    /**
+     * Sets the hostname/SNI that routes to this backend.
+     *
+     * @param hostname the hostname (e.g., "play.example.com"), or null to disable host-based routing
+     */
+    public void setHostname(String hostname) {
+        this.hostname = hostname;
+    }
+
+    /**
+     * Checks if this backend has hostname-based routing configured.
+     *
+     * @return true if hostname is set and not empty
+     */
+    public boolean hasHostname() {
+        return hostname != null && !hostname.isEmpty();
+    }
+
     @Override
     public String toString() {
-        return "BackendServer{" +
-            "name='" + name + '\'' +
-            ", host='" + host + '\'' +
-            ", port=" + port +
-            ", default=" + defaultServer +
-            '}';
+        StringBuilder sb = new StringBuilder("BackendServer{");
+        sb.append("name='").append(name).append('\'');
+        sb.append(", host='").append(host).append('\'');
+        sb.append(", port=").append(port);
+        sb.append(", default=").append(defaultServer);
+        if (hostname != null) {
+            sb.append(", hostname='").append(hostname).append('\'');
+        }
+        sb.append('}');
+        return sb.toString();
     }
 }
 

--- a/proxy/src/main/java/me/internalizable/numdrassl/config/ProxyConfig.java
+++ b/proxy/src/main/java/me/internalizable/numdrassl/config/ProxyConfig.java
@@ -147,12 +147,18 @@ public class ProxyConfig {
             // Backend servers
             writer.write("# ==================== Backend Servers ====================\n\n");
             writer.write("# List of backend servers players can connect to\n");
+            writer.write("# hostname: Optional hostname/SNI for host-based routing\n");
+            writer.write("#           If set, connections with this hostname route to this backend\n");
+            writer.write("#           Example: play.example.com -> lobby, survival.example.com -> survival\n");
             writer.write("backends:\n");
             for (BackendServer backend : backends) {
                 writer.write("  - name: \"" + backend.getName() + "\"\n");
                 writer.write("    host: \"" + backend.getHost() + "\"\n");
                 writer.write("    port: " + backend.getPort() + "\n");
                 writer.write("    defaultServer: " + backend.isDefaultServer() + "\n");
+                if (backend.getHostname() != null && !backend.getHostname().isEmpty()) {
+                    writer.write("    hostname: \"" + backend.getHostname() + "\"\n");
+                }
             }
             writer.write("\n");
 
@@ -406,6 +412,22 @@ public class ProxyConfig {
     public BackendServer getBackendByName(String name) {
         return backends.stream()
                 .filter(b -> b.getName().equalsIgnoreCase(name))
+                .findFirst()
+                .orElse(null);
+    }
+
+    /**
+     * Gets a backend server by its configured hostname/SNI.
+     *
+     * @param hostname the hostname to look up (case-insensitive)
+     * @return the backend server, or null if not found
+     */
+    public BackendServer getBackendByHostname(String hostname) {
+        if (hostname == null || hostname.isEmpty()) {
+            return null;
+        }
+        return backends.stream()
+                .filter(b -> b.hasHostname() && b.getHostname().equalsIgnoreCase(hostname))
                 .findFirst()
                 .orElse(null);
     }

--- a/proxy/src/main/java/me/internalizable/numdrassl/server/ProxyCore.java
+++ b/proxy/src/main/java/me/internalizable/numdrassl/server/ProxyCore.java
@@ -292,8 +292,14 @@ public final class ProxyCore {
         ProxyMetrics.getInstance().recordConnectionAccepted();
         ProxyMetrics.getInstance().incrementActiveSession();
 
-        LOGGER.info("New connection from {} (Session {})",
-            quicChannel.remoteAddress(), session.getSessionId());
+        String hostname = session.getClientHostname();
+        if (hostname != null) {
+            LOGGER.info("New connection from {} with hostname {} (Session {})",
+                quicChannel.remoteAddress(), hostname, session.getSessionId());
+        } else {
+            LOGGER.info("New connection from {} (Session {})",
+                quicChannel.remoteAddress(), session.getSessionId());
+        }
 
         eventManager.dispatchSessionCreated(session);
     }


### PR DESCRIPTION
This PR adds host-based routing functionality to Numdrassl, allowing players to be routed to specific backend servers based on the hostname/SNI they connect with. This enables scenarios where multiple hostnames (e.g., `play.example.com`, `survival.example.com`) point to the same proxy IP, with each routing to a different backend server.

## Changes

### Core Implementation

1. **SNI Extraction** (`SniExtractor.java`)
   - New utility class to extract Server Name Indication (SNI) from QUIC/TLS connections
   - Attempts multiple extraction methods for compatibility
   - Stores SNI in channel attributes for later retrieval

2. **Session Hostname Tracking** (`ProxySession.java`)
   - Added `clientHostname` field to store SNI from TLS handshake
   - Extracts hostname during session creation
   - Provides `getClientHostname()` method for access

3. **Backend Configuration** (`BackendServer.java`)
   - Added optional `hostname` field for host-based routing
   - Added `hasHostname()` helper method
   - Updated `toString()` to include hostname

4. **Routing Logic** (`BackendConnectionHandler.java`)
   - Updated `resolveBackend()` to check hostname/SNI first
   - Routing priority: Referrals → Hostname → Default backend
   - Logs hostname-based routing decisions

5. **Configuration Management** (`ProxyConfig.java`)
   - Added `getBackendByHostname()` method
   - Updated config save/load to support hostname field
   - Added documentation comments in generated config

### Documentation

- Updated `README.md` with host-based routing section
- Added configuration examples showing hostname field
- Documented DNS setup requirements

## Usage Example

```yaml
backends:
  - name: "lobby"
    host: "127.0.0.1"
    port: 5520
    defaultServer: true
    hostname: "play.example.com"  # Routes play.example.com → lobby

  - name: "survival"
    host: "192.168.1.100"
    port: 5520
    defaultServer: false
    hostname: "survival.example.com"  # Routes survival.example.com → survival
```

**DNS Setup:**
```
play.example.com     A  192.168.1.50
survival.example.com A  192.168.1.50
```

Both hostnames point to the proxy IP, but connections are routed based on SNI.

## Routing Priority

1. **Pending Referrals** (server transfers via `/server` command)
2. **Hostname/SNI Match** (if client connected with matching hostname)
3. **Default Backend** (fallback)

## Limitations

- SNI extraction relies on Netty QUIC's SSL session data
- Some clients may not send SNI (falls back to default backend)
- SNI extraction may not work in all network configurations
- Future enhancement: Add explicit SNI handler during SSL handshake for better reliability

## Testing

- [x] Configuration loading/saving with hostname field
- [x] Routing logic checks hostname before default
- [x] Backward compatible (hostname field is optional)
- [ ] SNI extraction from real QUIC connections (requires runtime testing)

## Backward Compatibility

✅ Fully backward compatible:
- `hostname` field is optional
- Existing configs without hostname continue to work
- Default backend fallback ensures no breaking changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Host-Based Routing Implementation

Category | Feature Addition

Impact (modules) | Config (BackendServer, ProxyConfig), Session Management (ProxySession), Connection Handling (BackendConnectionHandler, SniExtractor), Core (ProxyCore), Documentation (README)

Summary | 
Implements host/SNI-based routing so multiple hostnames resolving to the same proxy IP can route to different backends. Main changes:
- SniExtractor (new): utility to extract/store SNI from QUIC/TLS channels (stores in channel attribute, tries attribute → Netty SNI attribute → SSL session peer host, provides setHostname()).
- ProxySession: holds client QuicChannel for lazy SNI extraction; adds getClientHostname() with double-checked locking that invokes SniExtractor on first access.
- BackendServer: adds optional hostname field with get/set and hasHostname(); toString() updated to include hostname when present.
- ProxyConfig: adds getBackendByHostname(String) for case-insensitive hostname lookup; emits hostname in YAML save with explanatory comments; validates hostname uniqueness (throws on duplicates).
- BackendConnectionHandler: resolveBackend() now attempts routing by client hostname after pending referrals and before default backend; logs hostname-based selection.
- ProxyCore: conditional connection logging includes sanitized hostname when present; adds sanitizeHostname() to prevent log injection and enforce RFC1123-like restrictions.
- README.md: documents host-based routing, configuration examples, DNS notes, and SNI fallback behavior.

Routing priority | 1) Pending referrals 2) Hostname/SNI match 3) Default backend

Breaking Changes | None to public APIs. However, ProxyConfig now enforces unique hostnames and will throw an IllegalStateException on duplicate hostnames during defaults/application/save — this can surface as a configuration validation failure for existing configs that used duplicate hostname entries.

Compatibility | Backward compatible for configs without hostnames; hostname is optional. SNI extraction relies on Netty/QUIC SSL session data and may be unavailable for some clients — such clients fall back to referral/default routing. Configuration load/save format is extended but remains compatible; note the new uniqueness validation may require config fixes before upgrading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->