### PR TITLE
feat: Add PlayerChooseInitialServerEvent #47

### DIFF
--- a/api/src/main/java/me/internalizable/numdrassl/api/event/player/PlayerChooseInitialServerEvent.java
+++ b/api/src/main/java/me/internalizable/numdrassl/api/event/player/PlayerChooseInitialServerEvent.java
@@ -1,0 +1,78 @@
+package me.internalizable.numdrassl.api.event.player;
+
+import me.internalizable.numdrassl.api.event.ResultedEvent;
+import me.internalizable.numdrassl.api.player.Player;
+import me.internalizable.numdrassl.api.server.RegisteredServer;
+
+import javax.annotation.Nullable;
+
+/**
+ * Fired when a player’s initial backend server is being determined.
+ *
+ * <p>Allows listeners to override the selected server or explicitly request the
+ * default backend server.</p>
+ */
+public class PlayerChooseInitialServerEvent implements ResultedEvent<PlayerChooseInitialServerEvent.InitialServerResult> {
+
+    private final Player player;
+
+    private InitialServerResult result = InitialServerResult.useDefault();
+
+    public PlayerChooseInitialServerEvent(Player player) {
+        this.player = player;
+    }
+
+    public Player getPlayer() {
+        return player;
+    }
+
+    @Override
+    public InitialServerResult getResult() {
+        return result;
+    }
+
+    @Override
+    public void setResult(InitialServerResult result) {
+        this.result = result;
+    }
+
+    public static final class InitialServerResult implements Result {
+
+        private InitialServerMode mode = InitialServerMode.DEFAULT;
+
+        @Nullable
+        private final RegisteredServer initialServer;
+
+        public InitialServerResult(InitialServerMode mode, @Nullable RegisteredServer initialServer) {
+            this.mode = mode;
+            this.initialServer = initialServer;
+        }
+
+        @Override
+        public boolean isAllowed() {
+            return true;
+        }
+
+        @Nullable
+        public RegisteredServer getInitialServer() {
+            return initialServer;
+        }
+
+        public InitialServerMode getMode() {
+            return mode;
+        }
+
+        public static InitialServerResult useDefault() {
+            return new InitialServerResult(InitialServerMode.DEFAULT, null);
+        }
+
+        public static InitialServerResult useCustom(RegisteredServer server) {
+            return new InitialServerResult(InitialServerMode.CUSTOM, server);
+        }
+
+        public enum InitialServerMode {
+            CUSTOM,
+            DEFAULT
+        }
+    }
+}

--- a/docs/PLUGIN_DEVELOPMENT.md
+++ b/docs/PLUGIN_DEVELOPMENT.md
@@ -261,13 +261,14 @@ Priorities (in order): `FIRST` → `EARLY` → `NORMAL` → `LATE` → `LAST`
 | `DisconnectEvent` | Player disconnected | No |
 
 #### Player Events
-| Event | Description | Cancellable |
-|-------|-------------|-------------|
-| `PlayerChatEvent` | Player sends chat message | Yes |
-| `PlayerCommandEvent` | Player executes command | Yes |
-| `PlayerMoveEvent` | Player moves | Yes |
-| `PlayerBlockPlaceEvent` | Player places block | Yes |
-| `PlayerSlotChangeEvent` | Player changes hotbar slot | No |
+| Event                            | Description                                                          | Cancellable |
+|----------------------------------|----------------------------------------------------------------------|-------------|
+| `PlayerChatEvent`                | Player sends chat message                                            | Yes         |
+| `PlayerCommandEvent`             | Player executes command                                              | Yes         |
+| `PlayerMoveEvent`                | Player moves                                                         | Yes         |
+| `PlayerBlockPlaceEvent`          | Player places block                                                  | Yes         |
+| `PlayerSlotChangeEvent`          | Player changes hotbar slot                                           | No          |
+| `PlayerChooseInitialServerEvent` | Determines which backend server the player will connect to initially | No          |
 
 #### Server Events
 | Event | Description | Cancellable |

--- a/proxy/src/main/java/me/internalizable/numdrassl/pipeline/handler/BackendConnectionHandler.java
+++ b/proxy/src/main/java/me/internalizable/numdrassl/pipeline/handler/BackendConnectionHandler.java
@@ -1,7 +1,9 @@
 package me.internalizable.numdrassl.pipeline.handler;
 
 import com.hypixel.hytale.protocol.packets.connection.Connect;
+import me.internalizable.numdrassl.api.event.player.PlayerChooseInitialServerEvent;
 import me.internalizable.numdrassl.config.BackendServer;
+import me.internalizable.numdrassl.plugin.NumdrasslProxy;
 import me.internalizable.numdrassl.server.ProxyCore;
 import me.internalizable.numdrassl.session.ProxySession;
 import me.internalizable.numdrassl.session.SessionState;
@@ -74,6 +76,13 @@ public final class BackendConnectionHandler {
             }
         }
 
+        PlayerChooseInitialServerEvent.InitialServerResult initialServerResult = firePlayerChooseInitialServerEvent();
+        if (initialServerResult.getMode().equals(PlayerChooseInitialServerEvent.InitialServerResult.InitialServerMode.CUSTOM)) {
+            if (initialServerResult.getInitialServer() != null) {
+                return proxyCore.getConfig().getBackendByName(initialServerResult.getInitialServer().getName());
+            }
+        }
+
         // Fall back to default backend
         return proxyCore.getConfig().getDefaultBackend();
     }
@@ -86,6 +95,15 @@ public final class BackendConnectionHandler {
             session.getSessionId(), backend.getName());
 
         proxyCore.getBackendConnector().connect(session, backend, connect);
+    }
+
+    private PlayerChooseInitialServerEvent.InitialServerResult firePlayerChooseInitialServerEvent() {
+        NumdrasslProxy apiProxy = proxyCore.getApiProxy();
+        if (apiProxy == null) {
+            return PlayerChooseInitialServerEvent.InitialServerResult.useDefault();
+        }
+
+        return apiProxy.getEventBridge().firePlayerChooseInitialServerEvent(session);
     }
 }
 

--- a/proxy/src/main/java/me/internalizable/numdrassl/plugin/bridge/ApiEventBridge.java
+++ b/proxy/src/main/java/me/internalizable/numdrassl/plugin/bridge/ApiEventBridge.java
@@ -1,6 +1,7 @@
 package me.internalizable.numdrassl.plugin.bridge;
 
 import com.hypixel.hytale.protocol.Packet;
+import me.internalizable.numdrassl.api.event.player.PlayerChooseInitialServerEvent;
 import me.internalizable.numdrassl.config.BackendServer;
 import me.internalizable.numdrassl.event.mapping.PacketEventRegistry;
 import me.internalizable.numdrassl.event.packet.PacketEvent;
@@ -85,6 +86,14 @@ public final class ApiEventBridge implements PacketListener {
      */
     public void firePostLoginEvent(@Nonnull ProxySession session) {
         lifecycleHandler.onPostLogin(session);
+    }
+
+
+    /**
+     * Delegates the firing of {@link PlayerChooseInitialServerEvent}.
+     */
+    public PlayerChooseInitialServerEvent.InitialServerResult firePlayerChooseInitialServerEvent(@Nonnull ProxySession session) {
+        return lifecycleHandler.onPlayerChooseInitialServerEvent(session);
     }
 
     // ==================== Accessors ====================

--- a/proxy/src/main/java/me/internalizable/numdrassl/plugin/bridge/SessionLifecycleHandler.java
+++ b/proxy/src/main/java/me/internalizable/numdrassl/plugin/bridge/SessionLifecycleHandler.java
@@ -4,6 +4,7 @@ import me.internalizable.numdrassl.api.event.connection.AsyncLoginEvent;
 import me.internalizable.numdrassl.api.event.connection.DisconnectEvent;
 import me.internalizable.numdrassl.api.event.connection.PostLoginEvent;
 import me.internalizable.numdrassl.api.event.connection.PreLoginEvent;
+import me.internalizable.numdrassl.api.event.player.PlayerChooseInitialServerEvent;
 import me.internalizable.numdrassl.api.event.server.ServerConnectedEvent;
 import me.internalizable.numdrassl.api.event.server.ServerPreConnectEvent;
 import me.internalizable.numdrassl.api.player.Player;
@@ -308,6 +309,23 @@ public final class SessionLifecycleHandler {
             ServerConnectedEvent event = new ServerConnectedEvent(player, server, previousServer);
             eventManager.fireSync(event);
         }
+    }
+
+    /**
+     * Determines the initial backend server for a proxy session by firing
+     * a {@link PlayerChooseInitialServerEvent}.
+     *
+     * @return the event result or {@code null} if no override was provided
+     */
+    public PlayerChooseInitialServerEvent.InitialServerResult onPlayerChooseInitialServerEvent(@Nonnull ProxySession session) {
+        Objects.requireNonNull(session, "session");
+
+        Player player = getOrCreatePlayer(session);
+
+        PlayerChooseInitialServerEvent event = new PlayerChooseInitialServerEvent(player);
+        eventManager.fireSync(event);
+
+        return event.getResult();
     }
 
     // ==================== Helper Methods ====================

--- a/proxy/src/main/java/me/internalizable/numdrassl/plugin/bridge/SessionLifecycleHandler.java
+++ b/proxy/src/main/java/me/internalizable/numdrassl/plugin/bridge/SessionLifecycleHandler.java
@@ -321,6 +321,10 @@ public final class SessionLifecycleHandler {
         Objects.requireNonNull(session, "session");
 
         Player player = getOrCreatePlayer(session);
+        if (player == null) {
+            LOGGER.warn("Session {}: Cannot fire PlayerChooseInitialServerEvent - no player identity", session.getSessionId());
+            return PlayerChooseInitialServerEvent.InitialServerResult.useDefault();
+        }
 
         PlayerChooseInitialServerEvent event = new PlayerChooseInitialServerEvent(player);
         eventManager.fireSync(event);

--- a/proxy/src/main/java/me/internalizable/numdrassl/plugin/bridge/SessionLifecycleHandler.java
+++ b/proxy/src/main/java/me/internalizable/numdrassl/plugin/bridge/SessionLifecycleHandler.java
@@ -314,8 +314,10 @@ public final class SessionLifecycleHandler {
     /**
      * Determines the initial backend server for a proxy session by firing
      * a {@link PlayerChooseInitialServerEvent}.
-     *
-     * @return the event result or {@code null} if no override was provided
+     * <p>
+     * @param session the proxy session
+     * @return the event result indicating DEFAULT or CUSTOM server selection
+     * </p>
      */
     public PlayerChooseInitialServerEvent.InitialServerResult onPlayerChooseInitialServerEvent(@Nonnull ProxySession session) {
         Objects.requireNonNull(session, "session");


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
**Category** | Feature Addition - Player Initial Server Selection Event

**Impact (modules)** | API (`PlayerChooseInitialServerEvent`), Documentation (`PLUGIN_DEVELOPMENT.md`), Proxy Pipeline (`BackendConnectionHandler`), Plugin Bridge System (`ApiEventBridge`, `SessionLifecycleHandler`)

**Summary** | Adds `PlayerChooseInitialServerEvent` to let plugins influence which backend server a player is routed to initially. The event carries a mutable `InitialServerResult` with:
- mode: `DEFAULT` or `CUSTOM`
- initialServer: optional `RegisteredServer` (nullable)

Helpers: `InitialServerResult.useDefault()` and `useCustom(RegisteredServer)`. Public API: `getPlayer()`, `getResult()`, `setResult()`. `BackendConnectionHandler` now queries this event result and uses the provided custom server when mode is `CUSTOM`, otherwise falls back to default backend resolution. The event is fired via `SessionLifecycleHandler.onPlayerChooseInitialServerEvent(session)` and exposed to plugins through `ApiEventBridge.firePlayerChooseInitialServerEvent(session)`. Documentation updated to list `PlayerChooseInitialServerEvent` in the Player Events table (Cancellable: No).

**Breaking Changes** | None — additive only; no existing public signatures were modified.

**Compatibility** | Backward compatible. Default behavior unchanged when the event is not used or when handlers return `useDefault()`. Plugins may opt-in to override initial server selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->