### PR TITLE
feat: update ALPN protocols to include hytale/3

### DIFF
--- a/proxy/src/main/java/me/internalizable/numdrassl/server/ProxyCore.java
+++ b/proxy/src/main/java/me/internalizable/numdrassl/server/ProxyCore.java
@@ -66,7 +66,7 @@ public final class ProxyCore {
     private static final Logger LOGGER = LoggerFactory.getLogger(ProxyCore.class);
 
     private static final String[] ALPN_PROTOCOLS = {
-        "hytale/2", "hytale/1"
+        "hytale/3", "hytale/2", "hytale/1"
     };
 
     // Configuration


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

**Protocol Configuration** | **ProxyCore (Server-side QUIC/TLS)** | ALPN (Application-Layer Protocol Negotiation) protocols expanded from `["hytale/2", "hytale/1"]` to `["hytale/3", "hytale/2", "hytale/1"]`. During the QUIC/TLS handshake, clients can now negotiate hytale/3 protocol as the highest priority protocol version, with graceful fallback to hytale/2 and hytale/1. The proxy advertises support for hytale/3 during the ClientHello→ServerHello exchange, enabling protocol version negotiation with hytale/3-capable clients while maintaining backward compatibility with older clients. Backend connections already support hytale/3 (up to hytale/10). | **No breaking changes** — this is a backward-compatible enhancement. Clients supporting older protocol versions continue to function via protocol fallback negotiation. | **Forward compatible** — hytale/3 clients can now successfully negotiate hytale/3 with the proxy. Legacy clients (hytale/2, hytale/1) remain fully supported through ALPN fallback mechanism. No client-side changes required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->