### PR TITLE
docs: add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,101 @@
+name: Bug Report
+description: Report a bug or unexpected behavior in Numdrassl
+title: "[Bug]: "
+labels:
+  - bug
+  - needs-triage
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for taking the time to report an issue.
+        Please fill out the form as completely as possible so we can reproduce and fix the problem.
+
+  - type: input
+    id: proxy_version
+    attributes:
+      label: Numdrassl Proxy Version
+      description: "Version or release tag you are using (example: v1.2)"
+      placeholder: v1.2
+    validations:
+      required: true
+
+  - type: input
+    id: platform
+    attributes:
+      label: Platform
+      description: Operating system and architecture
+      placeholder: Linux / Windows
+    validations:
+      required: true
+
+  - type: input
+    id: hytale_version
+    attributes:
+      label: Hytale Server Version
+      description: Hytale server version(s) in use
+      placeholder: 2026.02.06-aa1b071c2
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Bug Description
+      description: Describe what happened and what you expected to happen
+      placeholder: |
+        What happened:
+        What you expected to happen:
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      description: Provide clear steps so the issue can be reproduced
+      placeholder: |
+        1. Start Numdrassl Proxy
+        2. Connect to server
+        3. Run /server lobby
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs
+      description: Relevant log output (remove sensitive data)
+      placeholder: Paste logs here
+      render: shell
+
+  - type: textarea
+    id: config
+    attributes:
+      label: Configuration
+      description: Relevant parts of your config.yml (remove secrets)
+      placeholder: Paste configuration here
+      render: yaml
+
+  - type: dropdown
+    id: reproducible
+    attributes:
+      label: Is the issue reproducible?
+      options:
+        - Always
+        - Sometimes
+        - Rarely
+        - Unable to reproduce
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: confirmation
+    attributes:
+      label: Confirmation
+      options:
+        - label: I am using the latest available release
+          required: true
+        - label: I have searched existing issues before opening this report
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Discord Support
+    url: https://discord.gg/54VFfuyUE8
+    about: Please use Discord for questions and support.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,80 @@
+name: Feature Request
+description: Suggest a new feature or improvement for Numdrassl
+title: "[Feature]: "
+labels:
+  - enhancement
+  - needs-review
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for your suggestion.
+        Please describe your idea clearly so we can evaluate it properly.
+
+  - type: input
+    id: summary
+    attributes:
+      label: Feature Summary
+      description: Short description of the requested feature
+      placeholder: "Example: Add weighted load balancing"
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem Statement
+      description: What problem does this feature solve?
+      placeholder: |
+        Describe the limitation or issue you are currently facing.
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      description: How should this feature work?
+      placeholder: |
+        Describe the expected behavior and configuration options.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: Any alternative solutions or workarounds you have tried
+      placeholder: |
+        Optional: Describe other approaches or why they are insufficient.
+
+  - type: textarea
+    id: impact
+    attributes:
+      label: Impact
+      description: Who benefits from this feature and why?
+      placeholder: |
+        Example: Server owners running multiple lobby servers.
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      description: How important is this feature to you?
+      options:
+        - Nice to have
+        - Important
+        - Critical
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: confirmation
+    attributes:
+      label: Confirmation
+      options:
+        - label: I have searched existing issues to ensure this feature was not already requested
+          required: true
+        - label: I understand that this feature may not be implemented immediately
+          required: true


### PR DESCRIPTION
for better issue reporting on github

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

**Documentation | Repository Infrastructure** | Added GitHub issue templates to standardize issue reporting. Introduces three new files: `bug_report.yml` with structured fields for bug reports (proxy version, platform, Hytale version, description, steps to reproduce, logs, configuration, reproducibility, and confirmation checkboxes), `feature_request.yml` with structured fields for feature requests (summary, problem statement, proposed solution, alternatives, impact, priority, and confirmation checks), and `config.yml` disabling blank issues and adding Discord support as a contact option. These templates enforce consistent information collection from contributors when creating issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->