### PR TITLE
remove player wrapper

### DIFF
--- a/proxy/src/main/java/me/internalizable/numdrassl/command/CommandEventListener.java
+++ b/proxy/src/main/java/me/internalizable/numdrassl/command/CommandEventListener.java
@@ -40,16 +40,13 @@ public class CommandEventListener {
             LOGGER.debug("Executing proxy command: /{} for player {}",
                 command, event.getPlayer().getUsername());
 
-            // Create a command source from the player
-            CommandSource source = new PlayerCommandSource(event.getPlayer());
-
             // Execute the command
             String fullCommand = event.getCommand();
             if (event.getArgs().length > 0) {
                 fullCommand += " " + String.join(" ", event.getArgs());
             }
 
-            CommandResult result = commandManager.execute(source, fullCommand);
+            CommandResult result = commandManager.execute(event.getPlayer(), fullCommand);
 
             // Send result message if any
             if (result.getMessage() != null) {
@@ -65,55 +62,4 @@ public class CommandEventListener {
             }
         }
     }
-
-    /**
-     * Command source implementation for players.
-     * Delegates permission checks to the player's permission function.
-     */
-    private static class PlayerCommandSource implements CommandSource {
-        private final Player player;
-
-        PlayerCommandSource(Player player) {
-            this.player = player;
-        }
-
-        @Override
-        public void sendMessage(@Nonnull String message) {
-            player.sendMessage(message);
-        }
-
-        @Override
-        @Nonnull
-        public Tristate getPermissionValue(@Nonnull String permission) {
-            return player.getPermissionValue(permission);
-        }
-
-        @Override
-        public boolean hasPermission(@Nonnull String permission) {
-            return player.hasPermission(permission);
-        }
-
-        @Override
-        @Nonnull
-        public PermissionFunction getPermissionFunction() {
-            return player.getPermissionFunction();
-        }
-
-        @Override
-        public void setPermissionFunction(@Nonnull PermissionFunction function) {
-            player.setPermissionFunction(function);
-        }
-
-        @Override
-        @Nonnull
-        public java.util.Optional<Player> asPlayer() {
-            return java.util.Optional.of(player);
-        }
-
-        @Override
-        public boolean isConsole() {
-            return false;
-        }
-    }
 }
-


### PR DESCRIPTION
destroys `CommandSource instanceof Player` check for no reason

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

**Command System Refactoring | Command Execution Module | Removed unnecessary PlayerCommandSource wrapper class and simplified direct Player object usage in command execution**

The PR eliminates the redundant `PlayerCommandSource` private static inner class that was wrapping `Player` objects before passing them to the command manager. Since `Player` already extends the `CommandSource` interface, the wrapper added no value beyond delegation. The change replaces the creation of intermediate wrapper instances with direct passing of the Player object to `commandManager.execute()`.

**Changes:**
- Removed `PlayerCommandSource` inner class from `CommandEventListener` 
- Modified `onPlayerCommand()` to directly pass `event.getPlayer()` to `commandManager.execute()` instead of wrapping it
- Eliminated all delegation methods that simply forwarded to the underlying Player instance

**Breaking Changes:** None. The change is purely internal refactoring.

**Compatibility:** Fully compatible. The `Player` interface already implements `CommandSource`, satisfying all type requirements of the `CommandManager.execute()` method signature. The behavior remains identical while reducing code complexity and unnecessary object instantiation.

**Code Impact:** +1 line / -55 lines

<!-- end of auto-generated comment: release notes by coderabbit.ai -->